### PR TITLE
feat: add public homepage quick link to admin interface

### DIFF
--- a/app/static/css/light.css
+++ b/app/static/css/light.css
@@ -1347,6 +1347,36 @@ input[type="password"] {
 }
 
 /* ===========================
+   Homepage Link
+   =========================== */
+.homepage-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--light-border);
+    border-radius: var(--border-radius);
+    color: var(--light-text-secondary);
+    cursor: pointer;
+    text-decoration: none;
+    transition: all var(--transition-fast);
+}
+
+.homepage-link:hover {
+    background-color: var(--light-hover-bg);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.homepage-link svg {
+    width: 18px;
+    height: 18px;
+}
+
+/* ===========================
    Responsive
    =========================== */
 @media (max-width: 1024px) {

--- a/app/templates/light/base.html
+++ b/app/templates/light/base.html
@@ -85,6 +85,12 @@
             <h1>{% block page_title %}Dashboard{% endblock %}</h1>
             <div class="header-actions">
                 {% block header_actions %}{% endblock %}
+                <a href="/" class="homepage-link" target="_blank" aria-label="View public homepage" title="View public homepage">
+                    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                        <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                    </svg>
+                </a>
                 <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle theme">
                     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>


### PR DESCRIPTION
Added a quick link button in the admin header that opens the public homepage in a new tab. The button features a home icon and matches the existing theme toggle button styling.

Changes:
- Add homepage link button in light interface header
- Add CSS styling for homepage link with hover effects
- Improve admin navigation UX

https://claude.ai/code/session_01Jp1HCCjpd1SKNTVJYjJNGi