### PR TITLE
feat: add drag-and-drop image upload for quick post creation

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -227,6 +227,8 @@ async def new_post(
     request: Request,
     db: AsyncSession = Depends(get_db),
     user: User | None = Depends(get_current_user),
+    media_id: int | None = None,
+    media_path: str | None = None,
 ) -> Response:
     """Render new post editor.
 
@@ -234,6 +236,8 @@ async def new_post(
         request: FastAPI request
         db: Database session
         user: Current user
+        media_id: Optional pre-uploaded media ID (from drag-drop)
+        media_path: Optional pre-uploaded media path (from drag-drop)
 
     Returns:
         Post editor page HTML
@@ -247,6 +251,14 @@ async def new_post(
     tag_service = TagService(db)
     tags = await tag_service.list_tags()
 
+    # If media was pre-uploaded via drag-drop, prepare initial content
+    initial_content = ""
+    initial_thumbnail = None
+    if media_id and media_path:
+        # Create markdown image reference
+        initial_content = f"![](/media/originals/{media_path})"
+        initial_thumbnail = f"/media/originals/{media_path}"
+
     context = get_base_context(request, user)
     context.update(
         {
@@ -254,6 +266,9 @@ async def new_post(
             "tags": tags,
             "all_tags": [t.name for t in tags],
             "statuses": [s.value for s in PostStatus],
+            "initial_content": initial_content,
+            "initial_thumbnail": initial_thumbnail,
+            "dropped_media_id": media_id,
         }
     )
     return templates.TemplateResponse("light/post_edit.html", context)

--- a/app/static/css/light.css
+++ b/app/static/css/light.css
@@ -742,6 +742,35 @@ input[type="password"] {
     color: var(--color-warning);
 }
 
+.badge-success {
+    background-color: var(--color-success-light);
+    color: var(--color-success);
+}
+
+/* ===========================
+   Dropped Media Preview (from drag-drop)
+   =========================== */
+.dropped-media-card {
+    border-color: var(--color-success);
+    background: linear-gradient(135deg, var(--color-success-light) 0%, var(--light-surface) 100%);
+}
+
+.dropped-media-preview {
+    max-width: 100%;
+    max-height: 300px;
+    overflow: hidden;
+    border-radius: var(--border-radius);
+    background: var(--light-bg);
+}
+
+.dropped-media-preview img {
+    max-width: 100%;
+    max-height: 300px;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto;
+}
+
 /* ===========================
    Pagination
    =========================== */

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1895,3 +1895,111 @@ video.immersive-bg-image {
     pointer-events: none;
     transition: opacity 0.4s ease;
 }
+
+/* ===========================
+   Drop Zone Overlay (Quick Post Creation)
+   =========================== */
+.drop-zone-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(37, 99, 235, 0.95);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.drop-zone-overlay.active {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.drop-zone-overlay.uploading {
+    background: rgba(37, 99, 235, 0.98);
+}
+
+.drop-zone-content {
+    text-align: center;
+    color: white;
+    padding: var(--spacing-2xl);
+    max-width: 400px;
+}
+
+.drop-zone-icon {
+    width: 80px;
+    height: 80px;
+    margin-bottom: var(--spacing-lg);
+    animation: dropZoneBounce 1s ease infinite;
+}
+
+.drop-zone-overlay.uploading .drop-zone-icon {
+    animation: dropZoneSpin 1s linear infinite;
+}
+
+@keyframes dropZoneBounce {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+@keyframes dropZoneSpin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.drop-zone-title {
+    font-size: var(--font-size-2xl);
+    font-weight: 600;
+    margin-bottom: var(--spacing-sm);
+}
+
+.drop-zone-hint {
+    font-size: var(--font-size-base);
+    opacity: 0.9;
+}
+
+.drop-zone-overlay.uploading .drop-zone-title {
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.7;
+    }
+}
+
+/* Dark mode adjustments */
+[data-theme="dark"] .drop-zone-overlay {
+    background: rgba(59, 130, 246, 0.95);
+}
+
+[data-theme="dark"] .drop-zone-overlay.uploading {
+    background: rgba(59, 130, 246, 0.98);
+}
+
+/* Drag-over body state indicator */
+body.drag-over::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    border: 4px dashed var(--color-primary);
+    pointer-events: none;
+    z-index: 9998;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1149,6 +1149,120 @@
     }
 
     /**
+     * Drag-and-Drop Post Creation
+     * Allows logged-in users to drop an image on any public page to create a new post
+     */
+    function initDragDropPostCreation() {
+        // Only enable for logged-in users
+        if (!document.body.hasAttribute('data-logged-in')) {
+            return;
+        }
+
+        const overlay = document.getElementById('drop-zone-overlay');
+        if (!overlay) return;
+
+        const titleEl = overlay.querySelector('.drop-zone-title');
+        const hintEl = overlay.querySelector('.drop-zone-hint');
+
+        let dragCounter = 0;
+
+        // Prevent default drag behaviors globally
+        ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+            document.addEventListener(eventName, (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+            }, false);
+        });
+
+        // Handle drag enter
+        document.addEventListener('dragenter', (e) => {
+            dragCounter++;
+
+            // Check if dragging files (images)
+            if (e.dataTransfer && e.dataTransfer.types.includes('Files')) {
+                overlay.classList.add('active');
+                document.body.classList.add('drag-over');
+            }
+        }, false);
+
+        // Handle drag leave
+        document.addEventListener('dragleave', (e) => {
+            dragCounter--;
+
+            if (dragCounter === 0) {
+                overlay.classList.remove('active');
+                document.body.classList.remove('drag-over');
+            }
+        }, false);
+
+        // Handle drag over (needed to allow drop)
+        document.addEventListener('dragover', (e) => {
+            e.dataTransfer.dropEffect = 'copy';
+        }, false);
+
+        // Handle drop
+        document.addEventListener('drop', async (e) => {
+            dragCounter = 0;
+            document.body.classList.remove('drag-over');
+
+            const files = e.dataTransfer.files;
+            if (!files || files.length === 0) {
+                overlay.classList.remove('active');
+                return;
+            }
+
+            // Get the first file
+            const file = files[0];
+
+            // Check if it's an image
+            if (!file.type.startsWith('image/')) {
+                overlay.classList.remove('active');
+                alert('Please drop an image file (JPG, PNG, GIF, WebP)');
+                return;
+            }
+
+            // Show uploading state
+            overlay.classList.add('uploading');
+            titleEl.textContent = 'Uploading...';
+            hintEl.textContent = file.name;
+
+            try {
+                // Upload the image
+                const formData = new FormData();
+                formData.append('file', file);
+
+                const response = await fetch('/api/media/upload', {
+                    method: 'POST',
+                    body: formData,
+                    credentials: 'include'
+                });
+
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.detail || 'Upload failed');
+                }
+
+                const media = await response.json();
+
+                // Redirect to post creation with media info
+                const params = new URLSearchParams({
+                    media_id: media.id,
+                    media_path: media.original_path
+                });
+
+                window.location.href = `/light/posts/new?${params.toString()}`;
+
+            } catch (error) {
+                console.error('Upload error:', error);
+                overlay.classList.remove('active', 'uploading');
+                titleEl.textContent = 'Drop image to create new post';
+                hintEl.textContent = 'Release to upload and start editing';
+                alert('Upload failed: ' + error.message);
+            }
+        }, false);
+    }
+
+    /**
      * Initialize all components
      */
     function init() {
@@ -1158,7 +1272,8 @@
         initKeyboardNavigation();
         initTouchNavigation();
         initPopstate();
-        
+        initDragDropPostCreation();
+
         // Page specific initializations
         initPage();
     }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,7 @@
     {% block meta_tags %}{% endblock %}
     {% block extra_css %}{% endblock %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
+<body class="{% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>
     {% block body %}{% endblock %}
     {% block extra_js %}{% endblock %}
 </body>

--- a/app/templates/light/post_edit.html
+++ b/app/templates/light/post_edit.html
@@ -39,6 +39,25 @@
                 </div>
             </div>
 
+            {% if initial_thumbnail %}
+            <!-- Dropped Image Preview -->
+            <div class="card dropped-media-card">
+                <div class="card-header flex-between">
+                    <h3>Dropped Image</h3>
+                    <span class="badge badge-success">Ready to use</span>
+                </div>
+                <div class="card-body">
+                    <div class="dropped-media-preview">
+                        <img src="{{ initial_thumbnail }}" alt="Dropped image preview">
+                    </div>
+                    <p class="text-small text-muted mt-2">
+                        This image has been uploaded and added to your post content.
+                        Give your post a title and save to publish.
+                    </p>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- Content -->
             <div class="card">
                 <div class="card-header flex-between">
@@ -56,7 +75,7 @@
                         class="form-textarea editor-content"
                         rows="20"
                         placeholder="Write your post content in Markdown..."
-                    >{{ post.content if post else '' }}</textarea>
+                    >{{ post.content if post else (initial_content if initial_content else '') }}</textarea>
                 </div>
             </div>
 
@@ -272,5 +291,10 @@ document.addEventListener('keydown', function(e) {
         document.getElementById('btn-save').click();
     }
 });
+
+{% if initial_thumbnail %}
+// Auto-focus title field when image was dropped
+document.getElementById('title').focus();
+{% endif %}
 </script>
 {% endblock %}

--- a/app/templates/public/base.html
+++ b/app/templates/public/base.html
@@ -35,8 +35,24 @@
 {% endblock %}
 
 {% block body_class %}public-layout{% endblock %}
+{% block body_attrs %}{% if user %}data-logged-in="true"{% endif %}{% endblock %}
 
 {% block body %}
+{% if user %}
+<!-- Drop Zone Overlay for Quick Post Creation -->
+<div class="drop-zone-overlay" id="drop-zone-overlay">
+    <div class="drop-zone-content">
+        <svg class="drop-zone-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="17 8 12 3 7 8"></polyline>
+            <line x1="12" y1="3" x2="12" y2="15"></line>
+        </svg>
+        <h2 class="drop-zone-title">Drop image to create new post</h2>
+        <p class="drop-zone-hint">Release to upload and start editing</p>
+    </div>
+</div>
+{% endif %}
+
 <div class="site-wrapper">
     <header class="site-header">
         <div class="header-container">


### PR DESCRIPTION
When logged in, users can now drag and drop an image onto any public page to quickly create a new post. The image is uploaded automatically and the user is redirected to the post editor with the image already embedded in the content.

Changes:
- Add drop zone overlay to public base template (visible only when logged in)
- Add CSS styles for drop zone with upload animation
- Implement JavaScript drag-and-drop handlers in main.js
- Update light router to accept media_id and media_path query params
- Modify post editor to show dropped image preview and auto-focus title