### PR TITLE
fix: prevent build and deploy workflow from running on PR creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The deploy.yml workflow was incorrectly triggering on pull_request events, causing the build job to run unnecessarily on PR creation. This was redundant since test.yml already handles all testing for PRs.

Changed the workflow to only trigger on:
- Push to main branch (after merge)
- Version tags (v*)

This ensures the build and deploy pipeline only runs when code is actually merged to main, not during the PR review process.