### PR TITLE
refactor: reorganize layout components - move tag filters to header a…

### DIFF
--- a/app/templates/public/base.html
+++ b/app/templates/public/base.html
@@ -47,6 +47,7 @@
                 <p class="site-subtitle">{{ blog_subtitle }}</p>
                 {% endif %}
             </div>
+            {% block header_filters %}{% endblock %}
             <nav class="site-nav">
                 <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle theme">
                     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -78,6 +79,7 @@
     <footer class="site-footer">
         <div class="footer-container">
             <div class="footer-content">
+                {% block footer_pagination %}{% endblock %}
                 <p class="footer-copyright"><a href="/light" class="admin-link">&copy;</a> {{ current_year }} {{ author_name }}</p>
                 {% if false and tag_cloud %}
                 <div class="tag-cloud footer-tags">

--- a/app/templates/public/index.html
+++ b/app/templates/public/index.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Home{% endblock %}
 
-{% block content %}
+{% block header_filters %}
 <div class="tags-filters">
     <a href="/" class="filter-btn active">All</a>
     {% for t in tags %}
@@ -16,7 +16,9 @@
         </svg>
     </a>
 </div>
+{% endblock %}
 
+{% block content %}
 <div class="posts-main">
     {% if posts %}
         <div class="posts-grid">
@@ -183,48 +185,6 @@
                 {% endif %}
             {% endfor %}
         </div>
-
-        {% if total_pages > 1 %}
-        <nav class="pagination" aria-label="Posts pagination">
-            {% if page > 1 %}
-            <a href="/?page={{ page - 1 }}" class="pagination-link ajax-link" aria-label="Previous page">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M15 18l-6-6 6-6"/>
-                </svg>
-            </a>
-            {% else %}
-            <span class="pagination-link disabled">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M15 18l-6-6 6-6"/>
-                </svg>
-            </span>
-            {% endif %}
-
-            {% for p in range(1, total_pages + 1) %}
-                {% if p == page %}
-                    <span class="pagination-link active">{{ p }}</span>
-                {% elif p == 1 or p == total_pages or (p >= page - 1 and p <= page + 1) %}
-                    <a href="/?page={{ p }}" class="pagination-link ajax-link">{{ p }}</a>
-                {% elif p == page - 2 or p == page + 2 %}
-                    <span class="pagination-ellipsis">&hellip;</span>
-                {% endif %}
-            {% endfor %}
-
-            {% if page < total_pages %}
-            <a href="/?page={{ page + 1 }}" class="pagination-link ajax-link" aria-label="Next page">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M9 18l6-6-6-6"/>
-                </svg>
-            </a>
-            {% else %}
-            <span class="pagination-link disabled">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M9 18l6-6-6-6"/>
-                </svg>
-            </span>
-            {% endif %}
-        </nav>
-        {% endif %}
     {% else %}
         <div class="empty-state">
             <div class="empty-state-icon">
@@ -238,6 +198,50 @@
             <p class="empty-state-text">Check back soon for new content.</p>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block footer_pagination %}
+{% if total_pages > 1 %}
+<nav class="pagination" aria-label="Posts pagination">
+    {% if page > 1 %}
+    <a href="/?page={{ page - 1 }}" class="pagination-link ajax-link" aria-label="Previous page">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M15 18l-6-6 6-6"/>
+        </svg>
+    </a>
+    {% else %}
+    <span class="pagination-link disabled">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M15 18l-6-6 6-6"/>
+        </svg>
+    </span>
+    {% endif %}
+
+    {% for p in range(1, total_pages + 1) %}
+        {% if p == page %}
+            <span class="pagination-link active">{{ p }}</span>
+        {% elif p == 1 or p == total_pages or (p >= page - 1 and p <= page + 1) %}
+            <a href="/?page={{ p }}" class="pagination-link ajax-link">{{ p }}</a>
+        {% elif p == page - 2 or p == page + 2 %}
+            <span class="pagination-ellipsis">&hellip;</span>
+        {% endif %}
+    {% endfor %}
+
+    {% if page < total_pages %}
+    <a href="/?page={{ page + 1 }}" class="pagination-link ajax-link" aria-label="Next page">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 18l6-6-6-6"/>
+        </svg>
+    </a>
+    {% else %}
+    <span class="pagination-link disabled">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 18l6-6-6-6"/>
+        </svg>
+    </span>
+    {% endif %}
+</nav>
+{% endif %}
 {% endblock %}
 
 {% block extra_js %}
@@ -291,6 +295,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     <h2 class="empty-state-title">No posts yet</h2>
                     <p class="empty-state-text">Check back soon for new content.</p>
                 </div>`;
+            renderPagination(null);
             return;
         }
 
@@ -412,56 +417,68 @@ document.addEventListener('DOMContentLoaded', function() {
 
         html += '</div>';
 
-        if (data.pagination && data.pagination.total_pages > 1) {
-            const pag = data.pagination;
+        postsMain.innerHTML = html;
+        renderPagination(data.pagination);
+    }
 
-            html += '<nav class="pagination" aria-label="Posts pagination">';
+    function renderPagination(pag) {
+        const paginationContainer = document.querySelector('.footer-content .pagination');
 
-            // Previous
-            if (pag.has_prev) {
-                html += `<a href="/?page=${pag.prev_page}" class="pagination-link ajax-link" aria-label="Previous page">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 18l-6-6 6-6"/>
-                    </svg>
-                </a>`;
-            } else {
-                html += `<span class="pagination-link disabled">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 18l-6-6 6-6"/>
-                    </svg>
-                </span>`;
-            }
-
-            // Pages
-            for (let p = 1; p <= pag.total_pages; p++) {
-                if (p === pag.page) {
-                    html += `<span class="pagination-link active">${p}</span>`;
-                } else if (p === 1 || p === pag.total_pages || (p >= pag.page - 1 && p <= pag.page + 1)) {
-                    html += `<a href="/?page=${p}" class="pagination-link ajax-link">${p}</a>`;
-                } else if (p === pag.page - 2 || p === pag.page + 2) {
-                    html += `<span class="pagination-ellipsis">&hellip;</span>`;
-                }
-            }
-
-            // Next
-            if (pag.has_next) {
-                html += `<a href="/?page=${pag.next_page}" class="pagination-link ajax-link" aria-label="Next page">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 18l6-6-6-6"/>
-                    </svg>
-                </a>`;
-            } else {
-                html += `<span class="pagination-link disabled">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 18l6-6-6-6"/>
-                    </svg>
-                </span>`;
-            }
-
-            html += '</nav>';
+        if (!paginationContainer) {
+            return;
         }
 
-        postsMain.innerHTML = html;
+        if (!pag || pag.total_pages <= 1) {
+            paginationContainer.style.display = 'none';
+            return;
+        }
+
+        paginationContainer.style.display = 'flex';
+
+        let html = '';
+
+        // Previous
+        if (pag.has_prev) {
+            html += `<a href="/?page=${pag.prev_page}" class="pagination-link ajax-link" aria-label="Previous page">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+            </a>`;
+        } else {
+            html += `<span class="pagination-link disabled">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+            </span>`;
+        }
+
+        // Pages
+        for (let p = 1; p <= pag.total_pages; p++) {
+            if (p === pag.page) {
+                html += `<span class="pagination-link active">${p}</span>`;
+            } else if (p === 1 || p === pag.total_pages || (p >= pag.page - 1 && p <= pag.page + 1)) {
+                html += `<a href="/?page=${p}" class="pagination-link ajax-link">${p}</a>`;
+            } else if (p === pag.page - 2 || p === pag.page + 2) {
+                html += `<span class="pagination-ellipsis">&hellip;</span>`;
+            }
+        }
+
+        // Next
+        if (pag.has_next) {
+            html += `<a href="/?page=${pag.next_page}" class="pagination-link ajax-link" aria-label="Next page">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 18l6-6-6-6"/>
+                </svg>
+            </a>`;
+        } else {
+            html += `<span class="pagination-link disabled">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 18l6-6-6-6"/>
+                </svg>
+            </span>`;
+        }
+
+        paginationContainer.innerHTML = html;
     }
 
     function attachListeners() {

--- a/app/templates/public/tag.html
+++ b/app/templates/public/tag.html
@@ -61,6 +61,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     <p class="empty-state-text">Check back later for new content.</p>
                     <a href="/" class="btn btn-primary" style="margin-top: 1rem;">Back to Home</a>
                 </div>`;
+            renderPagination(null);
             return;
         }
 
@@ -163,57 +164,69 @@ document.addEventListener('DOMContentLoaded', function() {
 
         html += '</div>';
 
-        if (data.pagination && data.pagination.total_pages > 1) {
-            const pag = data.pagination;
-            const tagSlug = data.tag ? data.tag.slug : '';
+        postsContainer.innerHTML = html;
+        renderPagination(data.pagination, data.tag);
+    }
 
-            html += '<nav class="pagination" aria-label="Tag archive pagination">';
+    function renderPagination(pag, tag) {
+        const paginationContainer = document.querySelector('.footer-content .pagination');
 
-            // Previous
-            if (pag.has_prev) {
-                html += `<a href="/tag/${tagSlug}?page=${pag.prev_page}" class="pagination-link ajax-link" aria-label="Previous page">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 18l-6-6 6-6"/>
-                    </svg>
-                </a>`;
-            } else {
-                html += `<span class="pagination-link disabled">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M15 18l-6-6 6-6"/>
-                    </svg>
-                </span>`;
-            }
-
-            // Pages
-            for (let p = 1; p <= pag.total_pages; p++) {
-                if (p === pag.page) {
-                    html += `<span class="pagination-link active">${p}</span>`;
-                } else if (p === 1 || p === pag.total_pages || (p >= pag.page - 1 && p <= pag.page + 1)) {
-                    html += `<a href="/tag/${tagSlug}?page=${p}" class="pagination-link ajax-link">${p}</a>`;
-                } else if (p === pag.page - 2 || p === pag.page + 2) {
-                    html += `<span class="pagination-ellipsis">&hellip;</span>`;
-                }
-            }
-
-            // Next
-            if (pag.has_next) {
-                html += `<a href="/tag/${tagSlug}?page=${pag.next_page}" class="pagination-link ajax-link" aria-label="Next page">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 18l6-6-6-6"/>
-                    </svg>
-                </a>`;
-            } else {
-                html += `<span class="pagination-link disabled">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 18l6-6-6-6"/>
-                    </svg>
-                </span>`;
-            }
-
-            html += '</nav>';
+        if (!paginationContainer) {
+            return;
         }
 
-        postsContainer.innerHTML = html;
+        if (!pag || pag.total_pages <= 1) {
+            paginationContainer.style.display = 'none';
+            return;
+        }
+
+        paginationContainer.style.display = 'flex';
+
+        const tagSlug = tag ? tag.slug : '';
+        let html = '';
+
+        // Previous
+        if (pag.has_prev) {
+            html += `<a href="/tag/${tagSlug}?page=${pag.prev_page}" class="pagination-link ajax-link" aria-label="Previous page">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+            </a>`;
+        } else {
+            html += `<span class="pagination-link disabled">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+            </span>`;
+        }
+
+        // Pages
+        for (let p = 1; p <= pag.total_pages; p++) {
+            if (p === pag.page) {
+                html += `<span class="pagination-link active">${p}</span>`;
+            } else if (p === 1 || p === pag.total_pages || (p >= pag.page - 1 && p <= pag.page + 1)) {
+                html += `<a href="/tag/${tagSlug}?page=${p}" class="pagination-link ajax-link">${p}</a>`;
+            } else if (p === pag.page - 2 || p === pag.page + 2) {
+                html += `<span class="pagination-ellipsis">&hellip;</span>`;
+            }
+        }
+
+        // Next
+        if (pag.has_next) {
+            html += `<a href="/tag/${tagSlug}?page=${pag.next_page}" class="pagination-link ajax-link" aria-label="Next page">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 18l6-6-6-6"/>
+                </svg>
+            </a>`;
+        } else {
+            html += `<span class="pagination-link disabled">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 18l6-6-6-6"/>
+                </svg>
+            </span>`;
+        }
+
+        paginationContainer.innerHTML = html;
     }
 
     function attachListeners() {
@@ -272,22 +285,24 @@ document.addEventListener('DOMContentLoaded', function() {
 <meta name="twitter:description" content="{% if tag.description %}{{ tag.description }}{% else %}Browse {{ total }} posts tagged with '{{ tag.name }}'{% endif %}">
 {% endblock %}
 
+{% block header_filters %}
+<div class="tags-filters">
+    <a href="/" class="filter-btn">All</a>
+    {% for t in tags %}
+    <a href="/tag/{{ t.slug }}" class="filter-btn {% if t.slug == tag.slug %}active{% endif %}">{{ t.name }}</a>
+    {% endfor %}
+    <a href="/tags" class="filter-btn" title="All Tags">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="1"></circle>
+            <circle cx="19" cy="12" r="1"></circle>
+            <circle cx="5" cy="12" r="1"></circle>
+        </svg>
+    </a>
+</div>
+{% endblock %}
+
 {% block content %}
 <div class="tag-archive">
-    <div class="tags-filters">
-        <a href="/" class="filter-btn">All</a>
-        {% for t in tags %}
-        <a href="/tag/{{ t.slug }}" class="filter-btn {% if t.slug == tag.slug %}active{% endif %}">{{ t.name }}</a>
-        {% endfor %}
-        <a href="/tags" class="filter-btn" title="All Tags">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="1"></circle>
-                <circle cx="19" cy="12" r="1"></circle>
-                <circle cx="5" cy="12" r="1"></circle>
-            </svg>
-        </a>
-    </div>
-
     <div id="tag-posts-container">
     {% if posts %}
     <div class="posts-grid">
@@ -454,49 +469,6 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
         {% endfor %}
     </div>
-
-    {% if total_pages > 1 %}
-    <nav class="pagination" aria-label="Tag archive pagination">
-        {% if page > 1 %}
-        <a href="/tag/{{ tag.slug }}?page={{ page - 1 }}" class="pagination-link ajax-link" aria-label="Previous page">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M15 18l-6-6 6-6"/>
-            </svg>
-        </a>
-        {% else %}
-        <span class="pagination-link disabled">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M15 18l-6-6 6-6"/>
-            </svg>
-        </span>
-        {% endif %}
-
-        {% for p in range(1, total_pages + 1) %}
-            {% if p == page %}
-                <span class="pagination-link active">{{ p }}</span>
-            {% elif p == 1 or p == total_pages or (p >= page - 1 and p <= page + 1) %}
-                <a href="/tag/{{ tag.slug }}?page={{ p }}" class="pagination-link ajax-link">{{ p }}</a>
-            {% elif p == page - 2 or p == page + 2 %}
-                <span class="pagination-ellipsis">&hellip;</span>
-            {% endif %}
-        {% endfor %}
-
-        {% if page < total_pages %}
-        <a href="/tag/{{ tag.slug }}?page={{ page + 1 }}" class="pagination-link ajax-link" aria-label="Next page">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M9 18l6-6-6-6"/>
-            </svg>
-        </a>
-        {% else %}
-        <span class="pagination-link disabled">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M9 18l6-6-6-6"/>
-            </svg>
-        </span>
-        {% endif %}
-    </nav>
-    {% endif %}
-
     {% else %}
     <div class="empty-state">
         <div class="empty-state-icon">
@@ -513,4 +485,48 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             </div>
         </div>
-        {% endblock %}
+{% endblock %}
+
+{% block footer_pagination %}
+{% if total_pages > 1 %}
+<nav class="pagination" aria-label="Tag archive pagination">
+    {% if page > 1 %}
+    <a href="/tag/{{ tag.slug }}?page={{ page - 1 }}" class="pagination-link ajax-link" aria-label="Previous page">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M15 18l-6-6 6-6"/>
+        </svg>
+    </a>
+    {% else %}
+    <span class="pagination-link disabled">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M15 18l-6-6 6-6"/>
+        </svg>
+    </span>
+    {% endif %}
+
+    {% for p in range(1, total_pages + 1) %}
+        {% if p == page %}
+            <span class="pagination-link active">{{ p }}</span>
+        {% elif p == 1 or p == total_pages or (p >= page - 1 and p <= page + 1) %}
+            <a href="/tag/{{ tag.slug }}?page={{ p }}" class="pagination-link ajax-link">{{ p }}</a>
+        {% elif p == page - 2 or p == page + 2 %}
+            <span class="pagination-ellipsis">&hellip;</span>
+        {% endif %}
+    {% endfor %}
+
+    {% if page < total_pages %}
+    <a href="/tag/{{ tag.slug }}?page={{ page + 1 }}" class="pagination-link ajax-link" aria-label="Next page">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 18l6-6-6-6"/>
+        </svg>
+    </a>
+    {% else %}
+    <span class="pagination-link disabled">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 18l6-6-6-6"/>
+        </svg>
+    </span>
+    {% endif %}
+</nav>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
…nd pagination to footer

- Add header_filters and footer_pagination blocks to public/base.html
- Move tags-filters from main content to header-container (between site-branding and site-nav)
- Move nav.pagination from main content to footer-content
- Update JavaScript in index.html and tag.html to handle relocated pagination
- Add renderPagination() function to dynamically update footer pagination via AJAX
- Improves space utilization by relocating navigation elements