### PR TITLE
Fix deployment pipeline to use commit SHA-based image tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      image_sha_tag: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,13 +131,14 @@ jobs:
       - name: Deploy to Production
         uses: appleboy/ssh-action@v1.0.3
         env:
-          BUILD_VERSION: ${{ steps.version.outputs.version }}
+          BUILD_VERSION: ${{ needs.build.outputs.version }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_SSH_PORT != '' && secrets.DEPLOY_SSH_PORT || 22 }}
-          envs: BUILD_VERSION
+          envs: BUILD_VERSION,IMAGE_TAG
           script: |
             cd ${{ secrets.DEPLOY_PATH != '' && secrets.DEPLOY_PATH || '/opt/photo-blog' }}
 
@@ -143,23 +147,26 @@ jobs:
               git pull origin main
             fi
 
-            # Set version in .env file
+            # Set version and image tag in .env file
             if [ -f .env ]; then
               sed -i '/^APP_VERSION=/d' .env
+              sed -i '/^IMAGE_TAG=/d' .env
               echo "APP_VERSION=${BUILD_VERSION}" >> .env
+              echo "IMAGE_TAG=${IMAGE_TAG:0:7}" >> .env
             else
               echo "APP_VERSION=${BUILD_VERSION}" > .env
+              echo "IMAGE_TAG=${IMAGE_TAG:0:7}" >> .env
             fi
 
             # Login to GitHub Container Registry (requires GHCR_TOKEN secret with read:packages scope)
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER != '' && secrets.GHCR_USER || github.repository_owner }} --password-stdin
 
-            # Pull latest Docker image explicitly by name
-            docker pull ghcr.io/dariy/point:latest
+            # Pull specific Docker image by SHA tag (first 7 chars of commit SHA)
+            echo "Pulling image with tag: ${IMAGE_TAG:0:7}"
+            docker pull ghcr.io/dariy/point:${IMAGE_TAG:0:7}
 
-            # Update docker-compose.yml to use correct image (in case it's outdated)
-            sed -i 's|image:.*photo-blog.*|image: ghcr.io/dariy/point:latest|g' docker-compose.yml 2>/dev/null || true
-            sed -i 's|image:.*photo-blog.*|image: ghcr.io/dariy/point:latest|g' docker-compose.prod.yml 2>/dev/null || true
+            # Also tag as latest for convenience
+            docker tag ghcr.io/dariy/point:${IMAGE_TAG:0:7} ghcr.io/dariy/point:latest
 
             # Backup database before deployment
             docker compose exec -T blog python -c "
@@ -170,7 +177,20 @@ jobs:
             " || echo "Backup failed, continuing deployment..."
 
             # Deploy new version
-            docker compose up -d blog
+            docker compose -f docker-compose.prod.yml up -d blog
+
+            # Verify correct image is running
+            echo "Verifying deployed image..."
+            DEPLOYED_IMAGE=$(docker inspect photo-blog-prod --format='{{.Config.Image}}' 2>/dev/null || docker inspect photo-blog --format='{{.Config.Image}}')
+            echo "Deployed image: ${DEPLOYED_IMAGE}"
+            echo "Expected tag: ${IMAGE_TAG:0:7}"
+
+            if [[ ! "${DEPLOYED_IMAGE}" =~ ${IMAGE_TAG:0:7} ]]; then
+              echo "ERROR: Deployed image tag does not match expected tag!"
+              echo "Expected: ghcr.io/dariy/point:${IMAGE_TAG:0:7}"
+              echo "Got: ${DEPLOYED_IMAGE}"
+              exit 1
+            fi
 
             # Wait for container to start
             echo "Waiting for container to start..."
@@ -225,7 +245,9 @@ jobs:
           echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ needs.build.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image Tag**: ${GITHUB_SHA:0:7}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Full Image**: ghcr.io/dariy/point:${GITHUB_SHA:0:7}" >> $GITHUB_STEP_SUMMARY
           echo "- **Environment**: prod" >> $GITHUB_STEP_SUMMARY
           echo "- **Host**: ${{ secrets.DEPLOY_HOST }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY

--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -1,0 +1,192 @@
+# Deployment Pipeline Fix - Old Image Issue
+
+**Date**: 2026-02-01
+**Issue**: Deployment pipeline was deploying old Docker images instead of newly built ones
+**Status**: ✅ Fixed
+
+## Problem Summary
+
+The deployment pipeline was deploying outdated Docker images, causing old files to appear in the running container even after successful builds and deployments.
+
+## Root Causes
+
+### 1. Missing Job Output Declaration
+**Location**: `.github/workflows/deploy.yml` line 49-106
+**Issue**: The `build` job generated a `version` output in the `steps.version.outputs.version` variable, but this was never declared as a job-level output. When the `deploy` job tried to reference it, the variable was empty.
+
+**Fix**: Added `outputs:` section to the `build` job:
+```yaml
+outputs:
+  version: ${{ steps.version.outputs.version }}
+  image_sha_tag: ${{ steps.meta.outputs.tags }}
+```
+
+### 2. Hard-coded Image Tag
+**Location**: `.github/workflows/deploy.yml` line 158
+**Issue**: The deployment script always pulled `ghcr.io/dariy/point:latest` regardless of what was actually built. This meant:
+- If the `:latest` tag wasn't updated in the registry, old images would be pulled
+- No guarantee the deployed image matched the current commit
+- No way to track which specific version was deployed
+
+**Fix**: Changed to pull specific SHA-based tag:
+```bash
+docker pull ghcr.io/dariy/point:${IMAGE_TAG:0:7}
+```
+
+### 3. Missing IMAGE_TAG Environment Variable
+**Location**: `.github/workflows/deploy.yml` line 131-141
+**Issue**: The `docker-compose.prod.yml` file expects an `IMAGE_TAG` environment variable (line 6), but this was never set during deployment, causing it to fall back to `:latest`.
+
+**Fix**: Added `IMAGE_TAG` to environment variables:
+```yaml
+env:
+  BUILD_VERSION: ${{ needs.build.outputs.version }}
+  IMAGE_TAG: ${{ github.sha }}
+```
+
+### 4. Ineffective sed Commands
+**Location**: `.github/workflows/deploy.yml` lines 161-162
+**Issue**: The sed commands tried to replace image names containing "photo-blog", but the actual image name is "point", so they never matched anything.
+
+**Fix**: Removed these ineffective commands and instead:
+- Set `IMAGE_TAG` in the `.env` file
+- Use `docker-compose.prod.yml` which already has proper variable substitution
+- Explicitly specify the compose file: `docker compose -f docker-compose.prod.yml up -d blog`
+
+### 5. No Deployment Verification
+**Issue**: There was no verification that the correct image was actually deployed and running.
+
+**Fix**: Added verification step:
+```bash
+# Verify correct image is running
+DEPLOYED_IMAGE=$(docker inspect photo-blog-prod --format='{{.Config.Image}}')
+if [[ ! "${DEPLOYED_IMAGE}" =~ ${IMAGE_TAG:0:7} ]]; then
+  echo "ERROR: Deployed image tag does not match expected tag!"
+  exit 1
+fi
+```
+
+## Changes Made
+
+### 1. `.github/workflows/deploy.yml`
+- ✅ Added job-level outputs to `build` job (lines 55-57)
+- ✅ Changed deploy job to use `needs.build.outputs.version` (line 134)
+- ✅ Added `IMAGE_TAG` environment variable (line 135)
+- ✅ Updated `envs` to include both variables (line 141)
+- ✅ Set `IMAGE_TAG` in `.env` file (lines 153, 155, 158)
+- ✅ Changed to pull specific SHA tag instead of `latest` (line 166)
+- ✅ Added local tagging of pulled image as `latest` (line 169)
+- ✅ Specified production compose file explicitly (line 180)
+- ✅ Added deployment verification (lines 182-193)
+- ✅ Updated deployment summary to include image tag (lines 231-232)
+
+### 2. `scripts/verify-deployment.sh` (New File)
+- ✅ Created verification script for manual deployment checking
+- Shows container name, image, version, and health status
+- Can be run on the server to verify which version is deployed
+
+## How It Works Now
+
+1. **Build Phase**:
+   - Builds Docker image with multiple tags including SHA-based tag (`${sha:0:7}`)
+   - Exports `version` and `image_sha_tag` as job outputs
+
+2. **Deploy Phase**:
+   - Receives build version and commit SHA from build job
+   - Sets both `APP_VERSION` and `IMAGE_TAG` in `.env` file
+   - Pulls specific image by SHA tag: `ghcr.io/dariy/point:${IMAGE_TAG:0:7}`
+   - Tags pulled image as `latest` locally
+   - Uses `docker-compose.prod.yml` which respects `IMAGE_TAG` variable
+   - Verifies the deployed container is running the correct image
+   - Fails deployment if image mismatch detected
+
+3. **Verification**:
+   - Automatic: Pipeline verifies image tag matches expected SHA
+   - Manual: Run `./scripts/verify-deployment.sh` on server
+
+## Testing the Fix
+
+### On Next Deployment
+The pipeline will now:
+1. Build image with tag matching commit SHA (first 7 chars)
+2. Pull that specific tag during deployment
+3. Verify the running container uses that exact image
+4. Display full image information in deployment summary
+
+### Manual Verification
+On the production server:
+```bash
+cd /opt/photo-blog
+./scripts/verify-deployment.sh
+```
+
+This will show:
+- Container name and status
+- Exact image being used
+- APP_VERSION from environment
+- IMAGE_TAG from `.env` file
+- Health check status
+
+### Checking Deployed Version
+```bash
+# Check running container image
+docker inspect photo-blog-prod --format='{{.Config.Image}}'
+
+# Check environment variables
+docker exec photo-blog-prod printenv APP_VERSION
+docker exec photo-blog-prod printenv IMAGE_TAG
+
+# Check .env file
+cat .env | grep -E "(APP_VERSION|IMAGE_TAG)"
+```
+
+## Prevention
+
+To prevent this issue in the future:
+
+1. **Always use specific tags**: Never rely solely on `:latest` tag in production
+2. **Verify deployments**: Always check that deployed image matches expected version
+3. **Use SHA tags**: Commit SHAs provide deterministic, immutable references
+4. **Test pipelines**: Test deployment pipeline changes in staging environment first
+5. **Monitor deployments**: Review deployment logs and summaries after each deployment
+
+## Related Files
+
+- `.github/workflows/deploy.yml` - Main deployment pipeline
+- `docker-compose.prod.yml` - Production compose configuration
+- `scripts/verify-deployment.sh` - Manual verification script
+
+## Additional Notes
+
+### Why SHA Tags?
+Using the first 7 characters of the commit SHA as the image tag provides:
+- **Determinism**: Same commit always uses same image
+- **Traceability**: Easy to map running container to source code commit
+- **Immutability**: SHA-based tags can't be accidentally overwritten
+- **Debugging**: Can quickly identify which code version is running
+
+### Image Tag Strategy
+The pipeline now creates multiple tags for each build:
+- `sha:7chars` - Primary deployment tag (e.g., `b0565bd`)
+- `main` - Branch-based tag
+- `latest` - Latest build on main branch
+
+For deployment, we use the SHA tag for determinism, then locally tag it as `latest` for convenience.
+
+### Rollback Procedure
+If you need to rollback to a previous version:
+```bash
+# Find previous commit SHA
+git log --oneline
+
+# Set IMAGE_TAG to previous commit
+export IMAGE_TAG=<previous-commit-sha>
+docker pull ghcr.io/dariy/point:${IMAGE_TAG:0:7}
+docker tag ghcr.io/dariy/point:${IMAGE_TAG:0:7} ghcr.io/dariy/point:latest
+
+# Update .env
+echo "IMAGE_TAG=${IMAGE_TAG:0:7}" >> .env
+
+# Redeploy
+docker compose -f docker-compose.prod.yml up -d blog
+```

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Deployment Verification Script
+# Checks which version of the application is currently deployed
+
+set -e
+
+echo "=== Deployment Verification ==="
+echo ""
+
+# Check if docker is available
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker is not installed or not in PATH"
+    exit 1
+fi
+
+# Find the container name (try both prod and dev names)
+CONTAINER_NAME=""
+if docker ps --format '{{.Names}}' | grep -q "photo-blog-prod"; then
+    CONTAINER_NAME="photo-blog-prod"
+elif docker ps --format '{{.Names}}' | grep -q "photo-blog"; then
+    CONTAINER_NAME="photo-blog"
+else
+    echo "❌ No running photo-blog container found"
+    echo ""
+    echo "Available containers:"
+    docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+    exit 1
+fi
+
+echo "📦 Container: $CONTAINER_NAME"
+echo ""
+
+# Get container information
+IMAGE=$(docker inspect $CONTAINER_NAME --format='{{.Config.Image}}')
+CREATED=$(docker inspect $CONTAINER_NAME --format='{{.Created}}')
+STATUS=$(docker inspect $CONTAINER_NAME --format='{{.State.Status}}')
+
+echo "🖼️  Image: $IMAGE"
+echo "📅 Created: $CREATED"
+echo "🚦 Status: $STATUS"
+echo ""
+
+# Get environment variables from container
+echo "🔧 Environment Configuration:"
+APP_VERSION=$(docker exec $CONTAINER_NAME printenv APP_VERSION 2>/dev/null || echo "not set")
+echo "   APP_VERSION: $APP_VERSION"
+
+# Try to get version from .env file if mounted
+if [ -f .env ]; then
+    echo ""
+    echo "📝 .env file configuration:"
+    grep "^APP_VERSION=" .env 2>/dev/null || echo "   APP_VERSION not in .env"
+    grep "^IMAGE_TAG=" .env 2>/dev/null || echo "   IMAGE_TAG not in .env"
+fi
+
+# Get image digest for verification
+echo ""
+echo "🔐 Image Digest:"
+docker inspect $IMAGE --format='{{index .RepoDigests 0}}' 2>/dev/null || echo "   Digest not available"
+
+# Check health status
+echo ""
+echo "💚 Health Status:"
+HEALTH=$(docker inspect $CONTAINER_NAME --format='{{.State.Health.Status}}' 2>/dev/null || echo "no healthcheck")
+echo "   Status: $HEALTH"
+
+if [ "$HEALTH" = "healthy" ] || [ "$HEALTH" = "no healthcheck" ]; then
+    # Try to call the application's version endpoint if it exists
+    echo ""
+    echo "🌐 Application Status:"
+    if docker exec $CONTAINER_NAME curl -f -s http://localhost:8000/health > /dev/null 2>&1; then
+        echo "   ✅ Health endpoint responding"
+    else
+        echo "   ❌ Health endpoint not responding"
+    fi
+fi
+
+echo ""
+echo "=== Verification Complete ==="


### PR DESCRIPTION
## Summary

Fixes a critical issue where the deployment pipeline was deploying outdated Docker images instead of newly built ones. The root cause was relying on the `:latest` tag which could be stale, combined with missing job outputs and environment variable configuration.

## Problem

The deployment pipeline had several issues that caused old images to be deployed:
1. Build job outputs weren't declared at the job level, so deploy job couldn't access the version
2. Deployment always pulled `ghcr.io/dariy/point:latest` regardless of what was built
3. `IMAGE_TAG` environment variable was never set, causing docker-compose to fall back to `:latest`
4. No verification that the correct image was actually deployed
5. Ineffective sed commands tried to replace non-existent image names

## Changes

### Workflow Updates (`.github/workflows/deploy.yml`)
- **Added job-level outputs** to `build` job to expose `version` and `image_sha_tag` for downstream jobs
- **Changed to SHA-based image tags**: Deploy now pulls `ghcr.io/dariy/point:${IMAGE_TAG:0:7}` (first 7 chars of commit SHA) instead of `:latest`
- **Set IMAGE_TAG environment variable** during deployment with the commit SHA
- **Updated .env file** to include both `APP_VERSION` and `IMAGE_TAG` variables
- **Added deployment verification** that checks the running container uses the expected image tag, failing if there's a mismatch
- **Explicit compose file**: Changed to use `docker-compose.prod.yml` explicitly
- **Enhanced deployment summary** to show the exact image tag being deployed

### New Files
- **`scripts/verify-deployment.sh`**: Manual verification script to check which version is currently deployed on the server
- **`DEPLOYMENT_FIX.md`**: Comprehensive documentation of the issue, fixes, and how to verify/rollback deployments

## Implementation Details

The fix uses a deterministic approach:
1. Build phase creates images tagged with commit SHA (e.g., `b0565bd`)
2. Deploy phase pulls that specific SHA-based tag
3. Locally tags it as `:latest` for convenience
4. Verifies the deployed container is running the correct image
5. Fails the deployment if image mismatch is detected

This ensures every deployment is traceable to a specific commit and prevents accidental deployment of stale images.

## Testing

The fix can be verified by:
- Checking the deployment summary shows the correct image tag
- Running `./scripts/verify-deployment.sh` on the server
- Inspecting the running container: `docker inspect photo-blog-prod --format='{{.Config.Image}}'`

https://claude.ai/code/session_01EUwLEuV4yJuZCTb8HLSSJE