### PR TITLE
Add Google Analytics and Tag Manager to CSP headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -92,10 +92,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             )
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "img-src 'self' data:; "
+            "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; "
             "media-src 'self'; "
-            "script-src 'self' 'unsafe-inline'; "
-            "style-src 'self' 'unsafe-inline'"
+            "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; "
+            "style-src 'self' 'unsafe-inline'; "
+            "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com"
         )
         return response
 


### PR DESCRIPTION
## Summary
Updated Content Security Policy (CSP) headers to allow Google Analytics and Google Tag Manager resources, enabling proper functionality of these analytics and tracking services.

## Key Changes
- **img-src**: Added `https://www.googletagmanager.com` and `https://www.google-analytics.com` to allow image resources from Google services
- **script-src**: Added `https://www.googletagmanager.com` to permit Google Tag Manager scripts
- **connect-src**: Added new directive to allow connections to Google Analytics and Google Tag Manager domains:
  - `https://www.google-analytics.com`
  - `https://*.google-analytics.com`
  - `https://*.analytics.google.com`
  - `https://*.googletagmanager.com`
- **style-src**: Added missing semicolon for consistency

## Implementation Details
These CSP modifications allow the application to integrate with Google's analytics ecosystem while maintaining security by explicitly whitelisting only the necessary Google domains. The wildcard subdomains (`*.`) ensure compatibility with various regional and service-specific endpoints that Google Analytics and Tag Manager may use.