### PR TITLE
fix: polish footer layout for immersive and mobile views

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1577,6 +1577,10 @@ img {
         grid-template-columns: 1fr;
     }
 
+    .site-footer {
+        padding-top: var(--spacing-lg);
+    }
+
     .footer-content {
         display: flex;
         flex-direction: column;
@@ -1586,7 +1590,6 @@ img {
 
     .footer-content .pagination {
         order: -1;
-        margin-bottom: var(--spacing-sm);
     }
 
     .footer-copyright {
@@ -1706,17 +1709,19 @@ img {
 }
 
 .immersive-layout .footer-content {
-    justify-content: flex-start;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
     text-align: left;
-    align-items: flex-start;
 }
 
-@media (max-width: 768px) {
-    .immersive-layout .footer-content {
-        flex-direction: column;
-        align-items: flex-start;
-        text-align: left;
-    }
+.immersive-layout .footer-content .immersive-tags {
+    align-self: flex-end;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    justify-content: flex-end;
+    pointer-events: auto;
 }
 
 [data-theme="light"].immersive-layout .site-footer .footer-link,
@@ -1748,32 +1753,6 @@ img {
     object-fit: contain;
     /* Show the whole image */
     transition: opacity 0.3s ease;
-}
-
-.immersive-tags-wrapper {
-    position: fixed;
-    bottom: var(--spacing-lg);
-    left: 0;
-    right: 0;
-    z-index: 60;
-    pointer-events: none;
-    transition: opacity 0.4s ease, transform 0.4s ease;
-}
-
-.immersive-tags {
-    max-width: var(--content-max-width);
-    margin: 0 auto;
-    padding: 0 var(--spacing-md);
-    display: flex;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-}
-
-.immersive-layout.ui-hidden .immersive-tags-wrapper {
-    opacity: 0;
-    transform: translateY(20px);
-    pointer-events: none;
 }
 
 .immersive-tags .post-tag {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -14,6 +14,9 @@
     function cleanupPage() {
         cleanupFunctions.forEach(fn => fn());
         cleanupFunctions = [];
+        // Clean up immersive tags from footer
+        const footerTags = document.querySelector('.footer-content .immersive-tags');
+        if (footerTags) footerTags.remove();
     }
 
     /**
@@ -654,6 +657,13 @@
                     });
                 }
 
+                // Update Footer (pagination, tags)
+                const newFooterContent = doc.querySelector('.footer-content');
+                const currentFooterContent = document.querySelector('.footer-content');
+                if (newFooterContent && currentFooterContent) {
+                    currentFooterContent.innerHTML = newFooterContent.innerHTML;
+                }
+
                 // Update document title
                 if (doc.title) document.title = doc.title;
 
@@ -811,16 +821,21 @@
                 }
             }
 
-            // Render Tags for Immersive
-            const tagsContainer = clone.querySelector('.immersive-tags');
-            if (tagsContainer && post.tags) {
-                post.tags.forEach(tag => {
-                    const a = document.createElement('a');
-                    a.href = '/tag/' + tag.slug;
-                    a.className = 'post-tag';
-                    a.textContent = tag.name;
-                    tagsContainer.appendChild(a);
-                });
+            // Render Tags for Immersive - add to footer
+            if (post.tags && post.tags.length > 0) {
+                const footerContent = document.querySelector('.footer-content');
+                if (footerContent) {
+                    const tagsDiv = document.createElement('div');
+                    tagsDiv.className = 'immersive-tags';
+                    post.tags.forEach(tag => {
+                        const a = document.createElement('a');
+                        a.href = '/tag/' + tag.slug;
+                        a.className = 'post-tag';
+                        a.textContent = tag.name;
+                        tagsDiv.appendChild(a);
+                    });
+                    footerContent.appendChild(tagsDiv);
+                }
             }
         }
 

--- a/app/templates/public/base.html
+++ b/app/templates/public/base.html
@@ -266,9 +266,6 @@ blog_settings.google_analytics_id }}"{% endif %}
                 </div>
             </div>
         </div>
-        <div class="immersive-tags-wrapper">
-            <div class="immersive-tags"></div>
-        </div>
     </div>
 </template>
 

--- a/app/templates/public/post.html
+++ b/app/templates/public/post.html
@@ -122,16 +122,6 @@ endblock %}
         {% endif %}
     </div>
 
-    {% if post.tags %}
-    <div class="immersive-tags-wrapper">
-        <div class="immersive-tags">
-            {% for tag in post.tags %}
-            <a href="/tag/{{ tag.slug }}" class="post-tag">{{ tag.name }}</a>
-            {% endfor %}
-        </div>
-    </div>
-    {% endif %}
-
     <!-- Post Info Card -->
     <!--div class="immersive-overlay-container">
         <div class="post-info-card">
@@ -252,4 +242,14 @@ endblock %}
 <div id="post-nav-data" style="display: none;" data-prev-url="{% if prev_post %}/posts/{{ prev_post.slug }}{% endif %}"
     data-next-url="{% if next_post %}/posts/{{ next_post.slug }}{% endif %}">
 </div>
+{% endblock %}
+
+{% block footer_pagination %}
+{% if not has_text_content and post.tags %}
+<div class="immersive-tags">
+    {% for tag in post.tags %}
+    <a href="/tag/{{ tag.slug }}" class="post-tag">{{ tag.name }}</a>
+    {% endfor %}
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Move immersive tags from separate fixed-position overlay into the
footer itself so they share a layout context with the copyright.
Tags now stack above copyright in a flex column, preventing overlap
when many tags wrap across lines.

For plain mode on mobile, increase footer top padding and clean up
spacing between pagination, copyright, and page bottom.

Also update AJAX navigation to sync footer content when navigating
between page types (post/list) and clean up immersive tags on
page transitions.

https://claude.ai/code/session_015ejQRhBuve6qWj8Xgm6ZSd