### PR TITLE
fix: restore theme toggle in immersive header, fix mobile spacing and AJAX tag refresh

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1578,7 +1578,7 @@ img {
     }
 
     .site-footer {
-        padding-top: var(--spacing-lg);
+        padding-top: var(--spacing-sm);
     }
 
     .footer-content {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1710,13 +1710,20 @@ img {
 
 .immersive-layout .footer-content {
     display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
+    flex-wrap: wrap-reverse;
+    align-items: flex-end;
+    gap: var(--spacing-xs) var(--spacing-md);
     text-align: left;
 }
 
+.immersive-layout .footer-content .footer-copyright {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
 .immersive-layout .footer-content .immersive-tags {
-    align-self: flex-end;
+    flex: 1 1 0%;
+    min-width: 0;
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-sm);

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -821,22 +821,6 @@
                 }
             }
 
-            // Render Tags for Immersive - add to footer
-            if (post.tags && post.tags.length > 0) {
-                const footerContent = document.querySelector('.footer-content');
-                if (footerContent) {
-                    const tagsDiv = document.createElement('div');
-                    tagsDiv.className = 'immersive-tags';
-                    post.tags.forEach(tag => {
-                        const a = document.createElement('a');
-                        a.href = '/tag/' + tag.slug;
-                        a.className = 'post-tag';
-                        a.textContent = tag.name;
-                        tagsDiv.appendChild(a);
-                    });
-                    footerContent.appendChild(tagsDiv);
-                }
-            }
         }
 
         // 3. Tags (Standard only)
@@ -998,6 +982,26 @@
 
         // Update Title
         document.title = post.title;
+
+        // Update footer tags for immersive posts
+        const existingFooterTags = document.querySelector('.footer-content .immersive-tags');
+        if (existingFooterTags) existingFooterTags.remove();
+
+        if (!hasText && post.tags && post.tags.length > 0) {
+            const footerContent = document.querySelector('.footer-content');
+            if (footerContent) {
+                const tagsDiv = document.createElement('div');
+                tagsDiv.className = 'immersive-tags';
+                post.tags.forEach(tag => {
+                    const a = document.createElement('a');
+                    a.href = '/tag/' + tag.slug;
+                    a.className = 'post-tag';
+                    a.textContent = tag.name;
+                    tagsDiv.appendChild(a);
+                });
+                footerContent.appendChild(tagsDiv);
+            }
+        }
 
         // Re-init
         initPage();

--- a/app/templates/public/post.html
+++ b/app/templates/public/post.html
@@ -62,6 +62,24 @@ endblock %}
             </svg>
         </a>
         {% endif %}
+        <button class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle theme">
+            <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+        </button>
     </div>
 </div>
 {% else %}


### PR DESCRIPTION

- Add theme toggle button to server-rendered immersive header
  (was present in AJAX template but missing from post.html)
- Fix mobile footer spacing: set padding-top to --spacing-sm so
  the gap between last image and pagination matches the gap
  between pagination and copyright (both ~1rem)
- Fix AJAX tag refresh: move immersive footer tag rendering to
  after DOM injection with explicit cleanup of old tags, ensuring
  tags always update when navigating between immersive posts