### PR TITLE
fix: remove duplicate 'All' links from homepage and tag pages

### DIFF
--- a/app/templates/public/index.html
+++ b/app/templates/public/index.html
@@ -4,7 +4,6 @@
 
 {% block header_filters %}
 <div class="tags-filters">
-    <a href="/" class="filter-btn active" data-role="all">All</a>
     {% for t in tags %}
     <a href="/tag/{{ t.slug }}" class="filter-btn">{{ t.name }}</a>
     {% endfor %}

--- a/app/templates/public/tag.html
+++ b/app/templates/public/tag.html
@@ -296,7 +296,6 @@
 {% block header_filters %}
 
 <div class="tags-filters">
-    <a href="/" class="filter-btn">All</a>
     {% for t in tags %}
     <a href="/tag/{{ t.slug }}" class="filter-btn {% if t.slug == tag.slug %}active{% endif %}">{{ t.name }}</a>
     {% endfor %}


### PR DESCRIPTION
Removed the redundant 'All' filter links from both the homepage (/) and tag pages (/tag/...) as they are functional duplicates of the logo link. The logo already navigates to the homepage, making these links unnecessary.

Changes:
- app/templates/public/index.html: Removed 'All' link from tags-filters
- app/templates/public/tag.html: Removed 'All' link from tags-filters

https://claude.ai/code/session_01Ry8BSAr2dQB1gr7v9x27no