### PR TITLE
fix: Improve database backup command and network driver

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,7 +242,7 @@ jobs:
             cd build
 
             # Backup database before deployment
-            docker exec -T point-prod python -c "
+            docker exec point-prod python -c "
             from app.services.backup_service import BackupService
             service = BackupService()
             backup_path = service.create_backup()

--- a/build/docker-compose.prod.yml
+++ b/build/docker-compose.prod.yml
@@ -98,4 +98,4 @@ volumes:
 networks:
   point-shared-network:
     name: point-shared-network
-    driver: bridge
+    external: true


### PR DESCRIPTION
The `-T` flag was removed from the `docker exec` command for database backups, as it is not necessary and can sometimes cause issues. Additionally, the `point-shared-network` is now configured as an external network, which is a more appropriate setup for production environments.