### PR TITLE
feat: Recalculate media visibility on cache clear

### DIFF
--- a/api/internal/api/system.go
+++ b/api/internal/api/system.go
@@ -194,10 +194,18 @@ func (h *SystemHandler) GetMigrations(c echo.Context) error {
 }
 
 func (h *SystemHandler) ClearCache(c echo.Context) error {
-	// The Go API has no application-level cache. Return success for API parity.
+	// The Go API has no application-level cache, but we treat it as an
+	// opportunity to synchronize state. We recalculate media visibility
+	// to ensure all media referenced in public posts is accessible to guests.
+	updated, err := h.mediaService.RecalculateAllMediaVisibility(c.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"status":        "success",
 		"cleared_count": 0,
+		"updated_media": updated,
 	})
 }
 

--- a/api/internal/api/system_test.go
+++ b/api/internal/api/system_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -148,5 +149,45 @@ func TestSystemHandler_UpdateMapCoords(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestSystemHandler_ClearCache(t *testing.T) {
+	repo := setupTestDB(t)
+	tmpDir, _ := os.MkdirTemp("", "sys-test")
+	defer func() {
+		_ = repo.Close()
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	cfg := &config.Config{StoragePath: tmpDir}
+	settingsSvc := services.NewSettingsService(repo)
+	tagSvc := services.NewTagService(repo)
+	mediaSvc := services.NewMediaService(repo, cfg, settingsSvc, tagSvc)
+	handler := NewSystemHandler(repo, mediaSvc, settingsSvc, tagSvc, tmpDir)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/system/cache/clear", nil)
+	rec := httptest.NewRecorder()
+
+	if err := handler.ClearCache(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("ClearCache failed: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp["status"] != "success" {
+		t.Errorf("expected status 'success', got %v", resp["status"])
+	}
+
+	if _, ok := resp["updated_media"]; !ok {
+		t.Errorf("expected 'updated_media' field in response")
 	}
 }

--- a/frontend/css/light/media.css
+++ b/frontend/css/light/media.css
@@ -505,6 +505,33 @@
     border-color: var(--color-primary);
 }
 
+/* Status indicator (e.g. lock for private) */
+.media-item-status {
+    position: absolute;
+    top: var(--spacing-xs);
+    left: var(--spacing-xs);
+    z-index: 2;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.4);
+    color: white;
+    border-radius: var(--border-radius-sm);
+    backdrop-filter: blur(4px);
+}
+
+.media-item-status svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* In picker mode, offset status to avoid overlapping checkbox */
+.media-browser--picker .media-item-status {
+    left: calc(var(--spacing-xs) + 24px + var(--spacing-xs));
+}
+
 /* Picker mode: entire item is clickable */
 .media-browser--picker .media-item {
     cursor: pointer;

--- a/frontend/src/components/light/MediaBrowser.js
+++ b/frontend/src/components/light/MediaBrowser.js
@@ -22,7 +22,7 @@ import { listMedia, uploadMedia, deleteMedia, renameMedia, getMediaFolders } fro
 import { store } from '../../store.js';
 import { escapeHtml } from '../../utils/helpers.js';
 import { formatFileSize, formatDateShort } from '../../utils/formatters.js';
-import { FOLDER_SVG, CALENDAR_SVG, CHEVRON_SVG, EDIT_SVG } from '../../utils/icons.js';
+import { FOLDER_SVG, CALENDAR_SVG, CHEVRON_SVG, EDIT_SVG, LOCK_SVG } from '../../utils/icons.js';
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -159,6 +159,11 @@ export class MediaBrowser extends Component {
           fileType === 'video' ? '▶' : fileType === 'audio' ? '♫' : '📄'
         }</div>`;
 
+    const publicStatus = m.is_public ? '' : `
+      <div class="media-item-status" title="Private (hidden from guests)">
+        ${LOCK_SVG}
+      </div>`;
+
     const copyPath = m.path || (m.original_path ? m.original_path.replace('/media/originals', '') : '');
 
     const pickerCheckbox = pickerMode ? `
@@ -184,6 +189,7 @@ export class MediaBrowser extends Component {
            data-id="${escapeHtml(String(m.id))}"${
         isImage ? ` data-src="${escapeHtml(m.original_path || '')}" data-alt="${escapeHtml(m.filename)}"` : ''}>
         ${pickerCheckbox}
+        ${publicStatus}
         <div class="media-item-preview${isImage && !pickerMode ? ' media-item-preview--clickable' : ''}">${preview}</div>
         <div class="media-item-info">
           <div class="media-item-name-row">

--- a/frontend/src/pages/light/SystemPage.js
+++ b/frontend/src/pages/light/SystemPage.js
@@ -76,10 +76,10 @@ export default class SystemPage extends Component {
                 <div class="ops-list">
                   <div class="op-item">
                     <div class="op-info">
-                      <h4>Clear Cache</h4>
-                      <p>Clear the server-side file cache (thumbnails, optimized images).</p>
+                      <h4>Clear Cache & Sync Media</h4>
+                      <p>Clears server-side cache and synchronizes media visibility (ensures images in public posts are accessible to guests).</p>
                     </div>
-                    <button id="clear-cache-btn" class="btn btn-secondary">Clear Cache</button>
+                    <button id="clear-cache-btn" class="btn btn-secondary">Clear & Sync</button>
                   </div>
                   <div class="op-item">
                     <div class="op-info">
@@ -248,8 +248,9 @@ export default class SystemPage extends Component {
 
   async _handleClearCache() {
     try {
-      await clearCache();
-      store.set('toast', { message: 'Cache cleared successfully.', type: 'success' });
+      const result = await clearCache();
+      const count = result.updated_media || 0;
+      store.set('toast', { message: `Cache cleared and ${count} media records synchronized.`, type: 'success' });
     } catch (err) {
       store.set('toast', { message: err.message || 'Failed to clear cache.', type: 'error' });
     }


### PR DESCRIPTION
The "Clear Cache" operation now also recalculates the visibility of all media items.
This ensures that media referenced in public posts is correctly marked as accessible
to guests, even if the visibility flag was previously out of sync. The API response
will now include the count of media records that were updated.