### PR TITLE
Fix: block system menu and image selection on long tap in immersive mode

### DIFF
--- a/frontend/css/public/immersive.css
+++ b/frontend/css/public/immersive.css
@@ -201,6 +201,9 @@
     background-color: var(--bg-primary);
     touch-action: none; /* Prevent scroll bouncing on swipe */
     overscroll-behavior: none; /* Prevent trackpad rubber-banding */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none; /* Block iOS long-tap image callout */
 }
 
 .immersive-visuals {

--- a/frontend/src/components/public/PostContent.js
+++ b/frontend/src/components/public/PostContent.js
@@ -786,6 +786,10 @@ export class PostContent extends Component {
       capture: true,
     });
 
+    this._on(wrapper, "contextmenu", (e) => {
+      e.preventDefault();
+    });
+
     this._on(wrapper, "click", (e) => {
       if (Date.now() - lastTouchTime < 500) return; // Ignore simulated click from touch
       if (e.target.closest("a, button, input, .post-info-card")) return;


### PR DESCRIPTION
## Summary
- Adds `contextmenu` event listener (with `preventDefault`) on the immersive wrapper to suppress the browser's system context menu that appears on long-tap (mobile and desktop right-click)
- Adds `user-select: none`, `-webkit-user-select: none`, and `-webkit-touch-callout: none` to `.immersive-wrapper` CSS to prevent text/image selection on long-press (especially iOS callout for images)

Closes point-3d46

## Test plan
- [ ] On mobile (iOS/Android), long-press on the immersive image — no system "Save Image / Open in New Tab" callout should appear
- [ ] Long-press on immersive background — no text selection handles or system menu
- [ ] Desktop right-click on the immersive image — no context menu
- [ ] Tapping, swiping, and pinch-zoom still work normally
- [ ] Buttons/links inside immersive overlay remain interactive (contextmenu only suppressed on the wrapper, not on anchors/buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)