### PR TITLE
feat: admin header buttons collapse to icon-only when overlapping title

### DIFF
--- a/frontend/css/light/layout.css
+++ b/frontend/css/light/layout.css
@@ -244,6 +244,18 @@ body {
     display: flex;
     gap: var(--spacing-sm);
     text-wrap-mode: nowrap;
+    flex-shrink: 0;
+}
+
+/* Icon-only compact mode — triggered via JS when h1 overlaps actions */
+.light-header.compact .header-actions .btn-label {
+    display: none;
+}
+
+.light-header.compact .header-actions .btn {
+    padding: var(--spacing-sm);
+    min-width: var(--header-action-btn-height, 2.5rem);
+    justify-content: center;
 }
 
 .light-content {

--- a/frontend/src/components/light/AdminLayout.js
+++ b/frontend/src/components/light/AdminLayout.js
@@ -15,6 +15,7 @@ import { Component } from '../Component.js';
 import { LightSidebar } from './LightSidebar.js';
 import { store } from '../../store.js';
 import { syncQueue } from '../../utils/sync.js';
+import { setupHeaderCompact } from '../../utils/headerCompact.js';
 
 export class AdminLayout extends Component {
   render() {
@@ -68,7 +69,17 @@ export class AdminLayout extends Component {
     return `<button class="${cls}" id="sync-pill-btn">${text}</button>`;
   }
 
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
+  beforeUnmount() {
+    this._cleanupHeaderCompact?.();
+  }
+
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     this.mountChild(LightSidebar, '#sidebar-mount', {
       currentPath: this.props.currentPath,
       user: this.props.user,

--- a/frontend/src/pages/light/DashboardPage.js
+++ b/frontend/src/pages/light/DashboardPage.js
@@ -11,7 +11,8 @@ import { logout } from '../../api/auth.js';
 import { store } from '../../store.js';
 import { escapeHtml, navigate } from '../../utils/helpers.js';
 import { formatFileSize } from '../../utils/formatters.js';
-import { REFRESH_SVG, WARNING_SVG } from '../../utils/icons.js';
+import { REFRESH_SVG, WARNING_SVG, PLUS_SVG } from '../../utils/icons.js';
+import { setupHeaderCompact } from '../../utils/headerCompact.js';
 
 export default class DashboardPage extends Component {
   constructor(container, props = {}) {
@@ -53,7 +54,7 @@ export default class DashboardPage extends Component {
               ${syncPill}
             </div>
             <div class="header-actions">
-              <a href="/light/posts/new" class="btn btn-primary">+ New Post</a>
+              <a href="/light/posts/new" class="btn btn-primary" title="New Post">${PLUS_SVG}<span class="btn-label">New Post</span></a>
             </div>
           </header>
           ${banner}
@@ -105,6 +106,7 @@ export default class DashboardPage extends Component {
   }
 
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     this.mountChild(LightSidebar, '#sidebar-mount', {
       currentPath: '/light',
       user: store.get('user') || {},
@@ -124,6 +126,15 @@ export default class DashboardPage extends Component {
         this.setState({ versionBanner: null });
       }
     });
+  }
+
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
+  beforeUnmount() {
+    this._cleanupHeaderCompact?.();
   }
 
   mount() {

--- a/frontend/src/pages/light/PostEditPage.js
+++ b/frontend/src/pages/light/PostEditPage.js
@@ -32,8 +32,9 @@ import { getAllShareEntries, clearShareEntries } from "../../utils/idb.js";
 import { logout } from "../../api/auth.js";
 import { store } from "../../store.js";
 import { escapeHtml, navigate, debounce } from "../../utils/helpers.js";
-import { SPARKLE_SVG, STAR_SVG, STAR_OUTLINE_SVG } from "../../utils/icons.js";
+import { SPARKLE_SVG, STAR_SVG, STAR_OUTLINE_SVG, TRASH_SVG, LINK_SVG, CHECK_SVG, X_SVG } from "../../utils/icons.js";
 import { VisualEditor } from "../../components/light/VisualEditor.js";
+import { setupHeaderCompact } from "../../utils/headerCompact.js";
 
 const AUTOSAVE_MS = 30_000;
 
@@ -222,18 +223,20 @@ export default class PostEditPage extends Component {
                 !isNew
                   ? `
                 <button id="delete-btn" class="btn btn-danger" type="button"
-                        title="Delete post" ${anyActionInProgress ? "disabled" : ""}>Delete</button>
+                        title="Delete post" ${anyActionInProgress ? "disabled" : ""}>${TRASH_SVG}<span class="btn-label">Delete</span></button>
                 <button id="preview-link-btn" class="btn btn-secondary" type="button"
                         title="Generate a shareable preview link (7 days)"
-                        ${anyActionInProgress ? "disabled" : ""}>${generatingPreview ? "Copying…" : "Preview link"}</button>
+                        ${anyActionInProgress ? "disabled" : ""}>${LINK_SVG}<span class="btn-label">${generatingPreview ? "Copying…" : "Preview link"}</span></button>
               `
                   : ""
               }
               <button id="analyze-btn" class="btn btn-secondary" type="button"
-                      ${anyActionInProgress ? "disabled" : ""}>${escapeHtml(analyzeLabel)}</button>
+                      title="${escapeHtml(analyzeLabel)}"
+                      ${anyActionInProgress ? "disabled" : ""}>${SPARKLE_SVG}<span class="btn-label">${escapeHtml(analyzeLabel)}</span></button>
               <button id="save-btn" class="btn btn-primary" type="button"
-                      ${anyActionInProgress ? "disabled" : ""}>${escapeHtml(saveLabel)}</button>
-              <a href="/light/posts" class="btn btn-secondary">Cancel</a>
+                      title="${escapeHtml(saveLabel)}"
+                      ${anyActionInProgress ? "disabled" : ""}>${CHECK_SVG}<span class="btn-label">${escapeHtml(saveLabel)}</span></button>
+              <a href="/light/posts" class="btn btn-secondary" title="Cancel">${X_SVG}<span class="btn-label">Cancel</span></a>
             </div>
           </header>
           <main class="light-content editor-full-width">
@@ -321,6 +324,7 @@ export default class PostEditPage extends Component {
   }
 
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     const postSlug = this.state.post?.slug;
     this.mountChild(LightSidebar, "#sidebar-mount", {
       currentPath: "/light/posts",
@@ -510,7 +514,13 @@ export default class PostEditPage extends Component {
     document.addEventListener("drop", this._onDrop);
   }
 
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
   beforeUnmount() {
+    this._cleanupHeaderCompact?.();
     this._unmounted = true; // Prevent pending debounced autosave from firing after navigation
     clearTimeout(this._autosaveTimer);
     document.removeEventListener("dragenter", this._onDragEnter);

--- a/frontend/src/pages/light/PostsListPage.js
+++ b/frontend/src/pages/light/PostsListPage.js
@@ -29,7 +29,10 @@ import {
   PLAY_SVG,
   MUSIC_SVG,
   RESTORE_SVG,
+  SELECT_SVG,
+  PLUS_SVG,
 } from "../../utils/icons.js";
+import { setupHeaderCompact } from "../../utils/headerCompact.js";
 
 const STATUS_LABELS = {
   published: "Published",
@@ -223,8 +226,8 @@ export default class PostsListPage extends Component {
           <header class="light-header">
             <h1>Posts</h1>
             <div class="header-actions">
-              ${!isTrash ? `<button id="select-mode-btn" class="btn">${selectMode ? "Cancel" : "Select"}</button>` : ""}
-              <a href="/light/posts/new" class="btn btn-primary">+ New Post</a>
+              ${!isTrash ? `<button id="select-mode-btn" class="btn" title="${selectMode ? "Cancel selection" : "Select posts"}">${selectMode ? X_SVG : SELECT_SVG}<span class="btn-label">${selectMode ? "Cancel" : "Select"}</span></button>` : ""}
+              <a href="/light/posts/new" class="btn btn-primary" title="New Post">${PLUS_SVG}<span class="btn-label">New Post</span></a>
             </div>
           </header>
           <main class="light-content">
@@ -276,6 +279,7 @@ export default class PostsListPage extends Component {
   }
 
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     this.mountChild(LightSidebar, "#sidebar-mount", {
       currentPath: "/light/posts",
       user: store.get("user") || {},
@@ -549,7 +553,13 @@ export default class PostsListPage extends Component {
     window.addEventListener("resize", this._onResize);
   }
 
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
   beforeUnmount() {
+    this._cleanupHeaderCompact?.();
     if (this._onResize) window.removeEventListener("resize", this._onResize);
   }
 

--- a/frontend/src/pages/light/SettingsPage.js
+++ b/frontend/src/pages/light/SettingsPage.js
@@ -15,6 +15,8 @@ import {
   navigate,
   normalizeSettings,
 } from "../../utils/helpers.js";
+import { CHECK_SVG } from "../../utils/icons.js";
+import { setupHeaderCompact } from "../../utils/headerCompact.js";
 
 const SETTING_GROUPS = [
   {
@@ -108,8 +110,8 @@ export default class SettingsPage extends Component {
           <header class="light-header">
             <h1>Settings</h1>
             <div class="header-actions">
-              <button type="submit" form="settings-form" class="btn btn-primary" ${saving ? "disabled" : ""}>
-                ${saving ? "Saving…" : "Save Settings"}
+              <button type="submit" form="settings-form" class="btn btn-primary" title="Save Settings" ${saving ? "disabled" : ""}>
+                ${CHECK_SVG}<span class="btn-label">${saving ? "Saving…" : "Save Settings"}</span>
               </button>
             </div>
           </header>
@@ -284,7 +286,17 @@ export default class SettingsPage extends Component {
       </div>`;
   }
 
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
+  beforeUnmount() {
+    this._cleanupHeaderCompact?.();
+  }
+
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     this.mountChild(LightSidebar, "#sidebar-mount", {
       currentPath: "/light/settings",
       user: store.get("user") || {},

--- a/frontend/src/pages/light/TagsManagerPage.js
+++ b/frontend/src/pages/light/TagsManagerPage.js
@@ -17,7 +17,8 @@ import { logout } from '../../api/auth.js';
 import { getNavMenu } from '../../api/pages.js';
 import { store } from '../../store.js';
 import { escapeHtml, navigate } from '../../utils/helpers.js';
-import { EDIT_SVG, X_SVG, REFRESH_SVG, LOCK_SVG, MAP_SVG, LIST_SVG, TREE_SVG, CHEVRON_SVG, CHEVRON_RIGHT_SVG } from '../../utils/icons.js';
+import { EDIT_SVG, X_SVG, REFRESH_SVG, LOCK_SVG, MAP_SVG, LIST_SVG, TREE_SVG, CHEVRON_SVG, CHEVRON_RIGHT_SVG, PLUS_SVG } from '../../utils/icons.js';
+import { setupHeaderCompact } from '../../utils/headerCompact.js';
 
 export default class TagsManagerPage extends Component {
   constructor(container, props = {}) {
@@ -62,13 +63,13 @@ export default class TagsManagerPage extends Component {
             <h1>Tags</h1>
             <div class="header-actions">
               <div class="tm-view-toggle">
-                <button id="view-tree-btn" class="btn btn-sm${view === 'tree' ? ' btn-primary' : ' btn-secondary'}" title="Tree view">${TREE_SVG} Tree</button>
-                <button id="view-list-btn" class="btn btn-sm${view === 'list' ? ' btn-primary' : ' btn-secondary'}" title="List view">${LIST_SVG} List</button>
+                <button id="view-tree-btn" class="btn btn-sm${view === 'tree' ? ' btn-primary' : ' btn-secondary'}" title="Tree view">${TREE_SVG}<span class="btn-label"> Tree</span></button>
+                <button id="view-list-btn" class="btn btn-sm${view === 'list' ? ' btn-primary' : ' btn-secondary'}" title="List view">${LIST_SVG}<span class="btn-label"> List</span></button>
               </div>
               ${view === 'tree' ? `
-              <button id="expand-all-btn" class="btn btn-sm btn-secondary" title="Expand all">\u21c5 Expand all</button>
-              <button id="collapse-all-btn" class="btn btn-sm btn-secondary" title="Collapse all">\u2012 Collapse all</button>` : ''}
-              <button id="add-root-tag-btn" class="btn btn-primary">+ New Tag</button>
+              <button id="expand-all-btn" class="btn btn-sm btn-secondary" title="Expand all">\u21c5<span class="btn-label"> Expand all</span></button>
+              <button id="collapse-all-btn" class="btn btn-sm btn-secondary" title="Collapse all">\u2012<span class="btn-label"> Collapse all</span></button>` : ''}
+              <button id="add-root-tag-btn" class="btn btn-primary" title="New Tag">${PLUS_SVG}<span class="btn-label"> New Tag</span></button>
               <button id="recalc-counts-btn" class="btn btn-secondary" title="Recalculate post counts">${REFRESH_SVG}</button>
             </div>
           </header>
@@ -351,9 +352,18 @@ export default class TagsManagerPage extends Component {
 
   mount() { super.mount(); this._load(); }
 
-  beforeUnmount() { this._closeModal(); }
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
+  beforeUnmount() {
+    this._cleanupHeaderCompact?.();
+    this._closeModal();
+  }
 
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     const tagSlug = this.props?.params?.slug;
     this.mountChild(LightSidebar, '#sidebar-mount', {
       currentPath: '/light/tags',

--- a/frontend/src/pages/light/ThemesPage.js
+++ b/frontend/src/pages/light/ThemesPage.js
@@ -11,7 +11,8 @@ import { logout } from "../../api/auth.js";
 import { parseTheme } from "../../utils/themeParser.js";
 import { store } from "../../store.js";
 import { escapeHtml, navigate } from "../../utils/helpers.js";
-import { STAR_SVG } from "../../utils/icons.js";
+import { STAR_SVG, SETTINGS_SVG } from "../../utils/icons.js";
+import { setupHeaderCompact } from "../../utils/headerCompact.js";
 
 export default class ThemesPage extends Component {
   constructor(container, props = {}) {
@@ -47,7 +48,7 @@ export default class ThemesPage extends Component {
           <header class="light-header">
             <h1>Themes</h1>
             <div class="header-actions">
-               <a href="/light/settings" class="btn btn-secondary">Settings</a>
+               <a href="/light/settings" class="btn btn-secondary" title="Settings">${SETTINGS_SVG}<span class="btn-label">Settings</span></a>
             </div>
           </header>
           <main class="light-content">
@@ -94,7 +95,17 @@ export default class ThemesPage extends Component {
       </div>`;
   }
 
+  beforeRender() {
+    this._cleanupHeaderCompact?.();
+    this._cleanupHeaderCompact = null;
+  }
+
+  beforeUnmount() {
+    this._cleanupHeaderCompact?.();
+  }
+
   afterRender() {
+    this._cleanupHeaderCompact = setupHeaderCompact(this.$('.light-header'));
     this.mountChild(LightSidebar, "#sidebar-mount", {
       currentPath: "/light/themes",
       user: store.get("user") || {},

--- a/frontend/src/utils/headerCompact.js
+++ b/frontend/src/utils/headerCompact.js
@@ -1,0 +1,32 @@
+/**
+ * Responsive compact mode for .light-header.
+ *
+ * When the h1 title and .header-actions overlap on the same line, adds
+ * class "compact" to .light-header so buttons collapse to icon-only mode.
+ */
+
+export function setupHeaderCompact(header) {
+  if (!header) return () => {};
+  const h1 = header.querySelector('h1');
+  const actions = header.querySelector('.header-actions');
+  if (!h1 || !actions) return () => {};
+
+  function check() {
+    // Measure without compact so we get natural sizes.
+    header.classList.remove('compact');
+
+    const h1Rect = h1.getBoundingClientRect();
+    const actionsRect = actions.getBoundingClientRect();
+
+    // Only collapse when both are on the same line (same-row check via top).
+    const sameRow = Math.abs(h1Rect.top - actionsRect.top) < actionsRect.height;
+    if (sameRow && h1Rect.right + 16 >= actionsRect.left) {
+      header.classList.add('compact');
+    }
+  }
+
+  const ro = new ResizeObserver(check);
+  ro.observe(header);
+  check();
+  return () => ro.disconnect();
+}

--- a/frontend/src/utils/icons.js
+++ b/frontend/src/utils/icons.js
@@ -338,3 +338,46 @@ export const MENU_SVG = `<svg width="18" height="18" viewBox="0 0 24 24" fill="n
   <line x1="7" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
   <line x1="11" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
 </svg>`;
+
+export const TRASH_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <polyline points="3 6 5 6 21 6" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10 11v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M14 11v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;
+
+export const CHECK_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;
+
+export const PLUS_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>`;
+
+export const SELECT_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="9 11 11 13 15 9" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="14" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <line x1="14" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <line x1="14" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>`;
+
+export const LINK_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;


### PR DESCRIPTION
## Summary

- Added `headerCompact.js` utility that uses `ResizeObserver` to detect when the h1 title and `.header-actions` buttons would overlap on the same line, then toggles a `compact` class on `.light-header`
- All admin header action buttons now show **icon + text** by default, collapsing to **icon-only with title tooltip** when space is tight
- New SVG icons added to `icons.js`: `TRASH_SVG`, `CHECK_SVG`, `PLUS_SVG`, `SELECT_SVG`, `LINK_SVG`
- Updated pages: PostEditPage, PostsListPage, DashboardPage, TagsManagerPage, SettingsPage, ThemesPage, AdminLayout

## Test plan

- [ ] Visit `/light` (Dashboard) at full width — "New Post" button should show icon + text
- [ ] Resize the browser narrower until the h1 title approaches the button — it should collapse to icon-only automatically
- [ ] Tooltip appears on hover in compact mode (native `title` attribute)
- [ ] At mobile breakpoint (≤640px), actions already drop to line 2 — compact mode does not apply
- [ ] PostEditPage: Delete, Preview link, Analyze, Save, Cancel all show icons at full width
- [ ] Tags page: Tree/List toggles, Expand/Collapse, New Tag — all show icons
- [ ] Settings page: Save Settings button shows checkmark icon

Closes point-5ogm

🤖 Generated with [Claude Code](https://claude.com/claude-code)