### PR TITLE
fix: release.yml is triggered after tag-release.yml. (#144)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (overrides git ref if provided)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+        type: string
 
 jobs:
   test:
@@ -90,7 +102,7 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=branch
             type=raw,value=latest
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
           labels: |
             org.opencontainers.image.title=Point
             org.opencontainers.image.description=Self-hosted personal photo blog engine

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,18 +3,22 @@ name: Tag release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   tag:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      new_tag: ${{ steps.create_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Calculate next version and create tag
+      - name: Read version and create tag
+        id: create_tag
         run: |
           # Fetch all tags to find the latest
           git fetch --tags --force
@@ -46,6 +50,7 @@ jobs:
           NEW_PATCH=$((PATCH + 1))
           NEW_TAG="v${MAJOR}.${MINOR}.${NEW_PATCH}"
           echo "New tag will be: $NEW_TAG"
+          echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
           
           # Final safety check: ensure the tag doesn't exist on remote
           if git ls-remote --tags origin "$NEW_TAG" | grep -q "$NEW_TAG"; then
@@ -58,3 +63,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$NEW_TAG"
           git push origin "$NEW_TAG"
+
+  release:
+    needs: tag
+    if: needs.tag.outputs.new_tag != ''
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.new_tag }}
+    secrets: inherit


### PR DESCRIPTION
* fix: release.yml is triggered after tag-release.yml

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / infrastructure

## Test plan

- [ ] `./scripts/run-tests.sh` passes
- [ ] Manually tested the affected feature

## Notes for reviewers

<!-- Anything specific to call out or highlight? -->
