### PR TITLE
Upgrade Go version to 1.26.3 in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, develop]
   schedule:
-    - cron: '30 1 * * 1'
+    - cron: "30 1 * * 1"
 
 jobs:
   analyze:
@@ -33,7 +33,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.26.3"
           cache-dependency-path: api/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,17 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (overrides git ref if provided)'
+        description: "Tag to release (overrides git ref if provided)"
         required: false
         type: string
   workflow_call:
     inputs:
       tag:
-        description: 'Tag to release'
+        description: "Tag to release"
         required: true
         type: string
 
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.26.3"
           cache-dependency-path: api/go.sum
 
       - name: Build CSS bundles
@@ -55,13 +55,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.26.3"
           cache-dependency-path: api/go.sum
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.25'
+          go-version-input: "1.26.3"
           go-package: ./...
           work-dir: api
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.26.3"
           cache-dependency-path: api/go.sum
 
       - name: Install golangci-lint
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.26.3"
           cache-dependency-path: api/go.sum
 
       - name: Build CSS bundles


### PR DESCRIPTION
This PR upgrades the Go version to 1.26.3 in the CI workflows as requested.