### PR TITLE
fix: update banner semver comparison + remove secret-leaking debug logs

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -409,6 +409,40 @@ func setupEcho(cfg config.Config, repo *repository.Repository, svcs *AppServices
 }
 
 func main() {
+	// Verbose logging of ALL arguments to help debug container environment mangling
+	for i, arg := range os.Args {
+		fmt.Printf("[DEBUG] arg[%d]: %q\n", i, arg)
+	}
+
+	// Check for CLI commands early.
+	// Some container engines (like podman-compose) might merge the command and args
+	// into a single string. We check for both "setup" as a standalone arg AND
+	// as the prefix of any argument.
+	isSetup := false
+	for _, arg := range os.Args {
+		trimmed := strings.Trim(arg, " \t\n\r\"'")
+		if trimmed == "setup" || strings.HasPrefix(trimmed, "setup ") {
+			isSetup = true
+			break
+		}
+	}
+
+	if isSetup {
+		fmt.Println("[INFO] CLI Setup command detected. Initializing...")
+		cfg, err := config.LoadConfig(".")
+		if err != nil {
+			log.Fatalf("setup: failed to load config: %v", err)
+		}
+		repo, err := repository.NewRepository(cfg.DatabaseURL)
+		if err != nil {
+			log.Fatalf("setup: failed to initialize repository: %v", err)
+		}
+		svcs := initServices(&cfg, repo)
+		fmt.Println("[INFO] Running CLI setup...")
+		runSetupCLI(repo, svcs)
+		os.Exit(0)
+	}
+
 	for _, arg := range os.Args[1:] {
 		if arg == "-v" || arg == "--version" || arg == "-version" {
 			fmt.Println(Version)
@@ -435,6 +469,8 @@ func main() {
 			log.Printf("error closing repository: %v", err)
 		}
 	}()
+
+	svcs := initServices(&cfg, repo)
 
 	// Ensure media directories exist
 	for _, dir := range []string{"originals", "thumbnails"} {
@@ -657,15 +693,6 @@ func main() {
 	// can share its name with the system tag (slug="_root"). Only slug stays unique.
 	if err := repo.DropTagNameUnique(ctx); err != nil {
 		log.Printf("warning: drop_tags_name_unique: %v", err)
-	}
-
-	svcs := initServices(&cfg, repo)
-
-	for _, arg := range os.Args[1:] {
-		if arg == "setup" {
-			runSetupCLI(repo, svcs)
-			os.Exit(0)
-		}
 	}
 
 	// Ensure a secret key is available for session signing.

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -661,6 +661,13 @@ func main() {
 
 	svcs := initServices(&cfg, repo)
 
+	for _, arg := range os.Args[1:] {
+		if arg == "setup" {
+			runSetupCLI(repo, svcs)
+			os.Exit(0)
+		}
+	}
+
 	// Ensure a secret key is available for session signing.
 	if err := svcs.Settings.EnsureSecretKey(ctx, &cfg); err != nil {
 		log.Fatalf("failed to ensure secret key: %v", err)

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -433,6 +433,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("setup: failed to load config: %v", err)
 		}
+		fmt.Printf("[DEBUG] DATABASE_URL: %q\n", cfg.DatabaseURL)
+		fmt.Printf("[DEBUG] STORAGE_PATH: %q\n", cfg.StoragePath)
+
 		repo, err := repository.NewRepository(cfg.DatabaseURL)
 		if err != nil {
 			log.Fatalf("setup: failed to initialize repository: %v", err)

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -409,39 +409,38 @@ func setupEcho(cfg config.Config, repo *repository.Repository, svcs *AppServices
 }
 
 func main() {
-	// Verbose logging of ALL arguments to help debug container environment mangling
+	// Verbose logging of ALL arguments using log.Printf to ensure visibility
+	log.Printf("[DEBUG-v4] Total args: %d", len(os.Args))
 	for i, arg := range os.Args {
-		fmt.Printf("[DEBUG] arg[%d]: %q\n", i, arg)
+		log.Printf("[DEBUG-v4] arg[%d]: %q", i, arg)
 	}
 
 	// Check for CLI commands early.
-	// Some container engines (like podman-compose) might merge the command and args
-	// into a single string. We check for both "setup" as a standalone arg AND
-	// as the prefix of any argument.
 	isSetup := false
 	for _, arg := range os.Args {
 		trimmed := strings.Trim(arg, " \t\n\r\"'")
-		if trimmed == "setup" || strings.HasPrefix(trimmed, "setup ") {
+		// Match "setup" as standalone OR part of a merged string like "point setup"
+		if trimmed == "setup" || strings.HasPrefix(trimmed, "setup ") || strings.Contains(trimmed, " setup ") || strings.HasSuffix(trimmed, " setup") {
 			isSetup = true
 			break
 		}
 	}
 
 	if isSetup {
-		fmt.Println("[INFO] CLI Setup command detected. Initializing...")
+		log.Println("[INFO] CLI Setup command detected. Initializing...")
 		cfg, err := config.LoadConfig(".")
 		if err != nil {
 			log.Fatalf("setup: failed to load config: %v", err)
 		}
-		fmt.Printf("[DEBUG] DATABASE_URL: %q\n", cfg.DatabaseURL)
-		fmt.Printf("[DEBUG] STORAGE_PATH: %q\n", cfg.StoragePath)
+		log.Printf("[DEBUG] DATABASE_URL: %q", cfg.DatabaseURL)
+		log.Printf("[DEBUG] STORAGE_PATH: %q", cfg.StoragePath)
 
 		repo, err := repository.NewRepository(cfg.DatabaseURL)
 		if err != nil {
 			log.Fatalf("setup: failed to initialize repository: %v", err)
 		}
 		svcs := initServices(&cfg, repo)
-		fmt.Println("[INFO] Running CLI setup...")
+		log.Println("[INFO] Running CLI setup...")
 		runSetupCLI(repo, svcs)
 		os.Exit(0)
 	}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -412,12 +412,6 @@ func setupEcho(cfg config.Config, repo *repository.Repository, svcs *AppServices
 }
 
 func main() {
-	// Verbose logging of ALL arguments using log.Printf to ensure visibility
-	log.Printf("[DEBUG-v4] Total args: %d", len(os.Args))
-	for i, arg := range os.Args {
-		log.Printf("[DEBUG-v4] arg[%d]: %q", i, arg)
-	}
-
 	// Check for CLI commands early.
 	isSetup := false
 	for _, arg := range os.Args {

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -22,9 +22,7 @@ func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
 		if trimmed == "setup" {
 			continue
 		}
-		if strings.HasPrefix(trimmed, "setup ") {
-			trimmed = strings.TrimPrefix(trimmed, "setup ")
-		}
+		trimmed = strings.TrimPrefix(trimmed, "setup ")
 
 		// Split by spaces but respect quotes would be complex.
 		// For now, let's just split by whitespace and see if it helps.

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"point-api/internal/models"
+	"point-api/internal/repository"
+	"point-api/internal/services"
+)
+
+func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
+	var blogTitle, authorName, email, password string
+
+	for i := 1; i < len(os.Args); i++ {
+		arg := os.Args[i]
+		if strings.HasPrefix(arg, "--title=") {
+			blogTitle = strings.TrimPrefix(arg, "--title=")
+		} else if strings.HasPrefix(arg, "--user=") {
+			authorName = strings.TrimPrefix(arg, "--user=")
+		} else if strings.HasPrefix(arg, "--email=") {
+			email = strings.TrimPrefix(arg, "--email=")
+		} else if strings.HasPrefix(arg, "--password=") {
+			password = strings.TrimPrefix(arg, "--password=")
+		}
+	}
+
+	if blogTitle == "" || authorName == "" || password == "" {
+		fmt.Println("Usage: point setup --title=\"Blog Title\" --user=\"Author Name\" --email=\"email@example.com\" --password=\"SHA256_HASH\"")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Check if already setup
+	_, err := repo.GetFirstUser(ctx)
+	if err == nil {
+		fmt.Println("Setup already complete.")
+		return
+	}
+
+	hash, err := services.HashPassword(password)
+	if err != nil {
+		log.Fatalf("failed to hash password: %v", err)
+	}
+
+	_, err = repo.CreateUser(ctx, models.CreateUserParams{
+		Username:     "the_owner",
+		Email:        email,
+		PasswordHash: hash,
+		DisplayName:  authorName,
+	})
+	if err != nil {
+		log.Fatalf("failed to create user: %v", err)
+	}
+
+	seedSettings := []struct {
+		key   string
+		value string
+		vType string
+	}{
+		{"blog_title", blogTitle, "string"},
+		{"author_name", authorName, "string"},
+		{"posts_per_page", "10", "integer"},
+		{"default_theme", "dark", "string"},
+		{"active_css_theme", "default", "string"},
+		{"use_thumbnails", "true", "boolean"},
+		{"show_view_counts", "false", "boolean"},
+		{"show_tag_cloud", "true", "boolean"},
+		{"map_mode", "off", "string"},
+		{"enable_backup", "false", "boolean"},
+	}
+
+	for _, s := range seedSettings {
+		if err := svcs.Settings.SetSetting(ctx, s.key, s.value, s.vType); err != nil {
+			log.Fatalf("failed to seed setting %s: %v", s.key, err)
+		}
+	}
+
+	fmt.Println("Setup complete!")
+}

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -15,8 +15,26 @@ import (
 func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
 	var blogTitle, authorName, email, password string
 
+	// Collect all parts from all arguments (handles merged args like "setup --title=...")
+	var allParts []string
 	for i := 1; i < len(os.Args); i++ {
-		arg := os.Args[i]
+		trimmed := strings.Trim(os.Args[i], " \t\n\r\"'")
+		if trimmed == "setup" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "setup ") {
+			trimmed = strings.TrimPrefix(trimmed, "setup ")
+		}
+
+		// Split by spaces but respect quotes would be complex.
+		// For now, let's just split by whitespace and see if it helps.
+		// Note: this will break titles with spaces IF they are passed as a single string.
+		// However, most container engines pass them as separate args if quoted.
+		parts := strings.Fields(trimmed)
+		allParts = append(allParts, parts...)
+	}
+
+	for _, arg := range allParts {
 		if val, ok := strings.CutPrefix(arg, "--title="); ok {
 			blogTitle = val
 		} else if val, ok := strings.CutPrefix(arg, "--user="); ok {
@@ -29,10 +47,13 @@ func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
 	}
 
 	if blogTitle == "" || authorName == "" || password == "" {
+		fmt.Printf("[ERROR] missing required setup arguments. Title: %q, User: %q, Password: [set: %v]\n", blogTitle, authorName, password != "")
+		fmt.Printf("[DEBUG] Received parts: %v\n", allParts)
 		fmt.Println("Usage: point setup --title=\"Blog Title\" --user=\"Author Name\" --email=\"email@example.com\" --password=\"SHA256_HASH\"")
 		os.Exit(1)
 	}
 
+	log.Printf("Starting CLI setup for blog %q with user %q", blogTitle, authorName)
 	ctx := context.Background()
 
 	// Check if already setup

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -17,14 +17,14 @@ func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
 
 	for i := 1; i < len(os.Args); i++ {
 		arg := os.Args[i]
-		if strings.HasPrefix(arg, "--title=") {
-			blogTitle = strings.TrimPrefix(arg, "--title=")
-		} else if strings.HasPrefix(arg, "--user=") {
-			authorName = strings.TrimPrefix(arg, "--user=")
-		} else if strings.HasPrefix(arg, "--email=") {
-			email = strings.TrimPrefix(arg, "--email=")
-		} else if strings.HasPrefix(arg, "--password=") {
-			password = strings.TrimPrefix(arg, "--password=")
+		if val, ok := strings.CutPrefix(arg, "--title="); ok {
+			blogTitle = val
+		} else if val, ok := strings.CutPrefix(arg, "--user="); ok {
+			authorName = val
+		} else if val, ok := strings.CutPrefix(arg, "--email="); ok {
+			email = val
+		} else if val, ok := strings.CutPrefix(arg, "--password="); ok {
+			password = val
 		}
 	}
 

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -48,7 +48,6 @@ func runSetupCLI(repo *repository.Repository, svcs *AppServices) {
 
 	if blogTitle == "" || authorName == "" || password == "" {
 		fmt.Printf("[ERROR] missing required setup arguments. Title: %q, User: %q, Password: [set: %v]\n", blogTitle, authorName, password != "")
-		fmt.Printf("[DEBUG] Received parts: %v\n", allParts)
 		fmt.Println("Usage: point setup --title=\"Blog Title\" --user=\"Author Name\" --email=\"email@example.com\" --password=\"SHA256_HASH\"")
 		os.Exit(1)
 	}

--- a/api/internal/api/system.go
+++ b/api/internal/api/system.go
@@ -81,7 +81,7 @@ func (h *SystemHandler) GetVersion(c echo.Context) error {
 		// On fetch failure: keep existing cache.Latest (may be empty string).
 	}
 
-	updateAvailable := cache.Latest != "" && cache.Latest != current
+	updateAvailable := cache.Latest != "" && semverGreaterThan(cache.Latest, current)
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"current":          current,
@@ -116,6 +116,37 @@ func fetchLatestGitHubRelease() (string, error) {
 		return "", err
 	}
 	return payload.TagName, nil
+}
+
+// semverGreaterThan returns true if version a is strictly greater than b.
+// Both strings may have an optional leading "v". Non-semver strings are treated as equal.
+func semverGreaterThan(a, b string) bool {
+	parse := func(v string) (int, int, int, bool) {
+		v = strings.TrimPrefix(v, "v")
+		parts := strings.SplitN(v, ".", 3)
+		if len(parts) != 3 {
+			return 0, 0, 0, false
+		}
+		major, e1 := strconv.Atoi(parts[0])
+		minor, e2 := strconv.Atoi(parts[1])
+		patch, e3 := strconv.Atoi(strings.SplitN(parts[2], "-", 2)[0])
+		if e1 != nil || e2 != nil || e3 != nil {
+			return 0, 0, 0, false
+		}
+		return major, minor, patch, true
+	}
+	aMaj, aMin, aPat, aOK := parse(a)
+	bMaj, bMin, bPat, bOK := parse(b)
+	if !aOK || !bOK {
+		return false
+	}
+	if aMaj != bMaj {
+		return aMaj > bMaj
+	}
+	if aMin != bMin {
+		return aMin > bMin
+	}
+	return aPat > bPat
 }
 
 func (h *SystemHandler) GetStats(c echo.Context) error {

--- a/api/internal/api/system_test.go
+++ b/api/internal/api/system_test.go
@@ -267,6 +267,43 @@ func TestSystemHandler_GetStats_Success(t *testing.T) {
 	}
 }
 
+func TestSemverGreaterThan(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		// major version differences
+		{"2.0.0", "1.0.0", true},
+		{"1.0.0", "2.0.0", false},
+		// minor version differences
+		{"1.2.0", "1.1.0", true},
+		{"1.1.0", "1.2.0", false},
+		// patch version differences
+		{"1.0.2", "1.0.1", true},
+		{"1.0.1", "1.0.2", false},
+		// equal versions
+		{"1.0.0", "1.0.0", false},
+		// v prefix stripped
+		{"v2.0.0", "v1.0.0", true},
+		{"v1.0.0", "v2.0.0", false},
+		// pre-release suffix ignored in comparison
+		{"1.0.2-beta", "1.0.1", true},
+		{"1.0.0-rc1", "1.0.0", false},
+		// invalid semver → false
+		{"not-a-version", "1.0.0", false},
+		{"1.0.0", "not-a-version", false},
+		{"1.0", "1.0.0", false},     // too few parts
+		{"1.0.abc", "1.0.0", false}, // non-numeric patch
+		{"a.0.0", "1.0.0", false},   // non-numeric major
+	}
+	for _, tc := range cases {
+		got := semverGreaterThan(tc.a, tc.b)
+		if got != tc.want {
+			t.Errorf("semverGreaterThan(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
 func TestSystemHandler_GetDiskInfo(t *testing.T) {
 	repo := setupTestDB(t)
 	tmpDir := t.TempDir()

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,14 +24,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
     -ldflags="-s -w -X main.Version=${BUILD_VERSION}" \
-    -o point cmd/api/main.go
+    -o point ./cmd/api
 
 # Build the path migration utility
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
     -ldflags="-s -w" \
-    -o migrate-paths cmd/migrate-paths/main.go
+    -o migrate-paths ./cmd/migrate-paths
 
 # Bundle and minify frontend JS
 COPY frontend/ ./frontend/

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -115,7 +115,7 @@ collect_config() {
   echo ""
 
   if [ "$method" = "docker" ]; then
-    INSTALL_DIR=$(maybe_ask "Install directory" "$HOME/point")
+    INSTALL_DIR=$(maybe_ask "Install directory" "$(pwd)")
     DATA_DIR=$(maybe_ask "Data directory" "${INSTALL_DIR}/data")
     APP_PORT=$(maybe_ask "Host Port" "${AUTO_PORT:-8000}")
     PORT=8000

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -483,7 +483,7 @@ prompt_account_setup() {
 
   if [ "$INSTALL_METHOD" = "docker" ]; then
     say "Running setup inside container..."
-    (cd "$INSTALL_DIR" && $COMPOSE exec -T -u 1000 point /app/point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
+    (cd "$INSTALL_DIR" && $COMPOSE exec -T -u 1000 -e DATABASE_URL=/data/point.db -e STORAGE_PATH=/data point /app/point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
   else
     (cd "$INSTALL_DIR" && DATABASE_URL="$DATA_DIR/point.db" STORAGE_PATH="$DATA_DIR" ./point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
     chown point:point "$DATA_DIR/point.db"* 2>/dev/null || true

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -478,10 +478,14 @@ prompt_account_setup() {
   local pass_hash; pass_hash=$(echo -n "$pass" | sha256sum | awk '{print $1}')
 
   say "Finalizing setup..."
+  local email_arg=""
+  [ -n "$email" ] && email_arg="--email=$email"
+
   if [ "$INSTALL_METHOD" = "docker" ]; then
-    (cd "$INSTALL_DIR" && $COMPOSE exec -T point /entrypoint.sh ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+    say "Running setup inside container..."
+    (cd "$INSTALL_DIR" && $COMPOSE exec -T -u 1000 point /app/point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
   else
-    (cd "$INSTALL_DIR" && DATABASE_URL="$DATA_DIR/point.db" STORAGE_PATH="$DATA_DIR" ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+    (cd "$INSTALL_DIR" && DATABASE_URL="$DATA_DIR/point.db" STORAGE_PATH="$DATA_DIR" ./point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
     chown point:point "$DATA_DIR/point.db"* 2>/dev/null || true
   fi
   ok "Admin account created!"

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -437,6 +437,56 @@ wait_for_health() {
   warn "Check logs with: journalctl -u point -f  (native)  or  docker logs point  (Docker)"
 }
 
+prompt_account_setup() {
+  if [ "$NON_INTERACTIVE" = "true" ]; then return; fi
+
+  # Check if setup is already complete
+  if curl -fsS "http://localhost:${APP_PORT}/api/setup/status" | grep -q '"setup_complete":true'; then
+    return
+  fi
+
+  echo ""
+  local do_setup
+  do_setup=$(ask_yn "Would you like to create an admin account now?" "y")
+  if [ "$do_setup" != "y" ]; then return; fi
+
+  echo ""
+  say "Admin Account Setup"
+  local title; title=$(ask "Blog Title" "My Photo Blog")
+  local name; name=$(ask "Your Name" "Admin")
+  local email; email=$(ask "Email Address" "")
+
+  local pass; local pass_confirm
+  while true; do
+    printf "${BOLD}Password: ${NC}" >&2
+    read -rs pass </dev/tty
+    echo "" >&2
+    printf "${BOLD}Confirm Password: ${NC}" >&2
+    read -rs pass_confirm </dev/tty
+    echo "" >&2
+    if [ "$pass" = "$pass_confirm" ] && [ -n "$pass" ]; then
+      if [ ${#pass} -lt 8 ]; then
+        err "Password must be at least 8 characters."
+      else
+        break
+      fi
+    else
+      err "Passwords do not match or are empty. Try again."
+    fi
+  done
+
+  local pass_hash; pass_hash=$(echo -n "$pass" | sha256sum | awk '{print $1}')
+
+  say "Finalizing setup..."
+  if [ "$INSTALL_METHOD" = "docker" ]; then
+    (cd "$INSTALL_DIR" && $COMPOSE exec -T point ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+  else
+    (cd "$INSTALL_DIR" && ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+    chown point:point "$DATA_DIR/point.db" 2>/dev/null || true
+  fi
+  ok "Admin account created!"
+}
+
 show_success() {
   local url="http://localhost:${APP_PORT}"
   echo ""
@@ -446,8 +496,12 @@ show_success() {
   echo ""
   echo -e "  ${BOLD}Open in your browser:${NC}  ${url}"
   echo ""
-  echo -e "  The setup wizard will appear on first visit."
-  echo -e "  Create your admin account and you're done."
+  if ! curl -fsS "http://localhost:${APP_PORT}/api/setup/status" | grep -q '"setup_complete":true'; then
+    echo -e "  The setup wizard will appear on first visit."
+    echo -e "  Create your admin account and you're done."
+  else
+    echo -e "  Log in at ${url}/light with the account you just created."
+  fi
   echo ""
   if [ "$INSTALL_METHOD" = "docker" ]; then
     echo -e "  ${BOLD}Useful commands:${NC}"
@@ -482,7 +536,9 @@ main() {
   fi
 
   wait_for_health
+  prompt_account_setup
   show_success
 }
 
 main "$@"
+

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -478,13 +478,21 @@ prompt_account_setup() {
   local pass_hash; pass_hash=$(echo -n "$pass" | sha256sum | awk '{print $1}')
 
   say "Finalizing setup..."
-  local email_arg=""
-  [ -n "$email" ] && email_arg="--email=$email"
 
   if [ "$INSTALL_METHOD" = "docker" ]; then
-    say "Running setup inside container..."
-    (cd "$INSTALL_DIR" && $COMPOSE exec -T -u 1000 -e DATABASE_URL=/data/point.db -e STORAGE_PATH=/data point /app/point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
+    say "Running setup via API..."
+    # Escape double-quotes and backslashes for safe JSON embedding
+    local title_j name_j email_j
+    title_j=$(printf '%s' "$title" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    name_j=$(printf '%s'  "$name"  | sed 's/\\/\\\\/g; s/"/\\"/g')
+    email_j=$(printf '%s' "$email" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    curl -fsS -X POST "http://localhost:${APP_PORT}/api/setup" \
+      -H "Content-Type: application/json" \
+      -d "{\"name\":\"${pass_hash}\",\"blog_title\":\"${title_j}\",\"author_name\":\"${name_j}\",\"email\":\"${email_j}\"}" \
+      >/dev/null
   else
+    local email_arg=""
+    [ -n "$email" ] && email_arg="--email=$email"
     (cd "$INSTALL_DIR" && DATABASE_URL="$DATA_DIR/point.db" STORAGE_PATH="$DATA_DIR" ./point setup "--title=$title" "--user=$name" $email_arg "--password=$pass_hash")
     chown point:point "$DATA_DIR/point.db"* 2>/dev/null || true
   fi

--- a/quickstart/install.sh
+++ b/quickstart/install.sh
@@ -479,10 +479,10 @@ prompt_account_setup() {
 
   say "Finalizing setup..."
   if [ "$INSTALL_METHOD" = "docker" ]; then
-    (cd "$INSTALL_DIR" && $COMPOSE exec -T point ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+    (cd "$INSTALL_DIR" && $COMPOSE exec -T point /entrypoint.sh ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
   else
-    (cd "$INSTALL_DIR" && ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
-    chown point:point "$DATA_DIR/point.db" 2>/dev/null || true
+    (cd "$INSTALL_DIR" && DATABASE_URL="$DATA_DIR/point.db" STORAGE_PATH="$DATA_DIR" ./point setup --title="$title" --user="$name" --email="$email" --password="$pass_hash")
+    chown point:point "$DATA_DIR/point.db"* 2>/dev/null || true
   fi
   ok "Admin account created!"
 }

--- a/quickstart/uninstall.sh
+++ b/quickstart/uninstall.sh
@@ -96,7 +96,7 @@ HAS_NATIVE=false
 echo ""
 say "Detecting Point installations..."
 
-DOCKER_INSTALL_DIR="${INSTALL_DIR_ARG:-$HOME/point}"
+DOCKER_INSTALL_DIR="${INSTALL_DIR_ARG:-$(pwd)}"
 if [ -f "$DOCKER_INSTALL_DIR/docker-compose.yml" ] || [ -d "$DOCKER_INSTALL_DIR/data" ]; then
     HAS_DOCKER=true
     say "Found Docker installation at $DOCKER_INSTALL_DIR"
@@ -149,7 +149,7 @@ fi
 uninstall_docker() {
     hr
     say "Uninstalling Docker version..."
-    local dir="${INSTALL_DIR_ARG:-$HOME/point}"
+    local dir="${INSTALL_DIR_ARG:-$(pwd)}"
     if [ ! -d "$dir" ]; then
         warn "Directory $dir not found. Skipping docker compose down."
     else


### PR DESCRIPTION
## Summary
- **Update banner fix** (`point-xkdd`): `update_available` was `true` whenever `current != latest`, including when running a dev build or pre-release newer than the published release. Replaced with a proper semver comparison (`semverGreaterThan`) so the banner only appears when `latest > current`.
- **Security: remove argv debug logs**: Two `[DEBUG]` blocks in `main.go` and `setup.go` dumped all of `os.Args` / parsed argument parts to stdout/logs on startup, exposing any secret passed as a CLI flag (including `--password=`) in logs and via `ps`. Both removed.
- Also includes quickstart/install changes from `feature-point-s0au` (merged in).

## Test plan
- [ ] Run a build with version higher than latest GitHub release — no update banner shown
- [ ] Run a build with version lower than latest GitHub release — update banner shown
- [ ] Run `point setup --password=secret` — confirm password does not appear in logs on argument parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)