### PR TITLE
Remove dead max_upload_size_mb setting; add zero-dim thumbnail bypass

### DIFF
--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	DatabaseURL string `mapstructure:"DATABASE_URL"`
 	StoragePath string `mapstructure:"STORAGE_PATH"`
 
-	MaxUploadSizeMB int `mapstructure:"MAX_UPLOAD_SIZE_MB"`
 	MaxImageWidth   int `mapstructure:"MAX_IMAGE_WIDTH"`
 	JpegQuality     int `mapstructure:"JPEG_QUALITY"`
 	ThumbnailWidth  int `mapstructure:"THUMBNAIL_WIDTH"`
@@ -64,7 +63,6 @@ func LoadConfig(path string) (config Config, err error) {
 	v.SetDefault("APP_VERSION", "")
 	v.SetDefault("SESSION_EXPIRY_HOURS", 720)
 	v.SetDefault("SESSION_EXPIRY_PUBLIC_HOURS", 24)
-	v.SetDefault("MAX_UPLOAD_SIZE_MB", 50)
 	v.SetDefault("THUMBNAIL_WIDTH", 400)
 	v.SetDefault("THUMBNAIL_HEIGHT", 300)
 	v.SetDefault("JPEG_QUALITY", 85)

--- a/api/internal/services/media_service.go
+++ b/api/internal/services/media_service.go
@@ -216,14 +216,16 @@ func (s *MediaService) UploadFile(ctx context.Context, p UploadFileParams) (mode
 			width = sql.NullInt64{Int64: int64(bounds.Dx()), Valid: true}
 			height = sql.NullInt64{Int64: int64(bounds.Dy()), Valid: true}
 
-			// Generate thumbnail
-			thumb := imaging.Fill(src, s.thumbnailWidth(ctx), s.thumbnailHeight(ctx), imaging.Center, imaging.Lanczos)
-			thumbFilename := strings.TrimSuffix(uniqueFilename, filepath.Ext(uniqueFilename)) + ".jpg"
-			thumbRel := filepath.Join("thumbnails", datePath, thumbFilename)
-			thumbFull := filepath.Join(s.cfg.StoragePath, "media", thumbRel)
-
-			if err := imaging.Save(thumb, thumbFull, imaging.JPEGQuality(s.jpegQuality(ctx))); err == nil {
-				thumbnailRelPath = sql.NullString{String: thumbRel, Valid: true}
+			// Generate thumbnail (skip if either dimension is 0 — use original instead)
+			thumbW, thumbH := s.thumbnailWidth(ctx), s.thumbnailHeight(ctx)
+			if thumbW > 0 && thumbH > 0 {
+				thumb := imaging.Fill(src, thumbW, thumbH, imaging.Center, imaging.Lanczos)
+				thumbFilename := strings.TrimSuffix(uniqueFilename, filepath.Ext(uniqueFilename)) + ".jpg"
+				thumbRel := filepath.Join("thumbnails", datePath, thumbFilename)
+				thumbFull := filepath.Join(s.cfg.StoragePath, "media", thumbRel)
+				if err := imaging.Save(thumb, thumbFull, imaging.JPEGQuality(s.jpegQuality(ctx))); err == nil {
+					thumbnailRelPath = sql.NullString{String: thumbRel, Valid: true}
+				}
 			}
 		}
 		// Extract EXIF

--- a/build/.env.example
+++ b/build/.env.example
@@ -33,7 +33,6 @@ DATABASE_URL=sqlite:./data/point.db
 # For Docker: /data
 # For local dev: ./data
 STORAGE_PATH=./data
-MAX_UPLOAD_SIZE_MB=10
 STORAGE_QUOTA_MB=5000
 MAX_IMAGE_WIDTH=2560
 JPEG_QUALITY=85

--- a/frontend/src/pages/light/SettingsPage.js
+++ b/frontend/src/pages/light/SettingsPage.js
@@ -52,7 +52,6 @@ const SETTING_GROUPS = [
   {
     title: "Advanced",
     keys: [
-      "max_upload_size_mb",
       "thumbnail_width",
       "thumbnail_height",
       "jpeg_quality",
@@ -70,7 +69,6 @@ const SETTING_GROUPS = [
 ];
 
 const NUMERIC_KEYS = new Set([
-  "max_upload_size_mb",
   "thumbnail_width",
   "thumbnail_height",
   "jpeg_quality",


### PR DESCRIPTION
## Summary

- **Remove `max_upload_size_mb`**: This setting was stored in DB and shown in admin UI but never enforced at upload time. Upload size limits belong at the nginx/reverse-proxy layer where they're actually effective. Removes the field from `config.go`, `build/.env.example`, and `SettingsPage.js`.
- **Zero-dimension thumbnail bypass**: When `thumbnail_width` or `thumbnail_height` is set to 0, thumbnail generation is now skipped. Post cards then fall back to the original image (via `extractMediaURL`'s existing fallback logic). Previously, passing 0 to `imaging.Fill` would produce a bad/empty image.

## Test plan

- [ ] Open `/light/settings` — "Max Upload Size Mb" field is gone from Advanced section
- [ ] Upload an image with default settings — thumbnail is still generated normally
- [ ] Set `thumbnail_width` or `thumbnail_height` to 0 in settings, upload a new image — no thumbnail file is created; post card displays the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)