### PR TITLE
feat: Add copy button to pre>code blocks

### DIFF
--- a/frontend/css/public/single-post.css
+++ b/frontend/css/public/single-post.css
@@ -121,6 +121,43 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-sm);
     transition: background-color var(--transition-theme);
+    position: relative;
+}
+
+.code-copy-btn {
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: var(--color-white-alpha-10);
+    color: var(--code-text);
+    border: none;
+    border-radius: var(--border-radius-sm);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast), scale var(--transition-fast);
+}
+
+.post-content pre:hover .code-copy-btn,
+.code-copy-btn:focus-visible {
+    opacity: 1;
+}
+
+.code-copy-btn:hover {
+    background: var(--color-white-alpha-20);
+}
+
+.code-copy-btn:active {
+    scale: 0.97;
+}
+
+.code-copy-btn.copied {
+    color: var(--color-success, #22c55e);
 }
 
 .post-content code {

--- a/frontend/src/components/public/PostContent.js
+++ b/frontend/src/components/public/PostContent.js
@@ -14,6 +14,7 @@
 
 import { Component } from "../Component.js";
 import { escapeHtml, safeUrl, navigate } from "../../utils/helpers.js";
+import { COPY_SVG, CHECK_SVG } from "../../utils/icons.js";
 import {
   buildTagIndex,
   renderTagStrip,
@@ -152,6 +153,7 @@ export class PostContent extends Component {
       if (bodyEl) {
         this._enhanceLinks(bodyEl);
         this._enhanceMedia(bodyEl);
+        this._enhanceCodeBlocks(bodyEl);
       }
       if (prevPost || nextPost) this._initNormal(prevPost, nextPost);
 
@@ -1053,6 +1055,37 @@ export class PostContent extends Component {
         });
       });
     }
+  }
+
+  _enhanceCodeBlocks(body) {
+    const parseSvg = (svgString) => {
+      const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+      return doc.documentElement;
+    };
+
+    body.querySelectorAll("pre").forEach((pre) => {
+      const code = pre.querySelector("code");
+      if (!code) return;
+
+      const btn = document.createElement("button");
+      btn.className = "code-copy-btn";
+      btn.setAttribute("aria-label", "Copy code");
+      btn.appendChild(parseSvg(COPY_SVG));
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(code.textContent || "").then(() => {
+          btn.replaceChildren(parseSvg(CHECK_SVG));
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.replaceChildren(parseSvg(COPY_SVG));
+            btn.classList.remove("copied");
+          }, 1500);
+        }).catch(() => {});
+      });
+
+      pre.appendChild(btn);
+    });
   }
 
   _renderNav(prev, next) {

--- a/frontend/src/utils/icons.js
+++ b/frontend/src/utils/icons.js
@@ -401,3 +401,11 @@ export const CHART_SVG = `<svg width="18" height="18" viewBox="0 0 24 24" fill="
   <path d="M12 20V4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <path d="M6 20V14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>`;
+
+export const COPY_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+  xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="9" y="9" width="13" height="13" rx="2" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;


### PR DESCRIPTION
## Summary

- Adds a clipboard icon button to the top-right corner of every `<pre><code>` block in post content
- Button is hidden until the user hovers the block (or focuses it via keyboard)
- Clicking copies the code text; button briefly switches to a checkmark to confirm
- SVG nodes built via `DOMParser` to avoid `innerHTML`

## Test plan

- [ ] Navigate to a post containing a fenced code block
- [ ] Hover the block — copy button should appear in the top-right corner
- [ ] Click the button — code is copied to clipboard and icon changes to a checkmark for ~1.5 s
- [ ] Verify no copy button appears on inline `<code>` elements
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)