### PR TITLE
feat(timeline): refresh map pins during drag

### DIFF
--- a/frontend/src/components/public/Timeline.js
+++ b/frontend/src/components/public/Timeline.js
@@ -24,6 +24,7 @@ export class Timeline extends Component {
       popover: null,
       isLoading: true,
     };
+    this._lastLiveEmit = 0;
   }
 
   /**
@@ -699,13 +700,30 @@ export class Timeline extends Component {
 
   _debounceEmitRange() {
     clearTimeout(this._emitTimer);
+
+    // Live refresh while dragging/zooming (throttled)
+    if (this._isDragging && this.props.mode === "filter") {
+      const now = Date.now();
+      if (now - this._lastLiveEmit > 100) {
+        this._emitRange();
+        this._lastLiveEmit = now;
+      }
+    }
+
     this._emitTimer = setTimeout(() => {
-      if (this._isDragging) return;
-      this._snapToCenterPill(() => {
-        if (this.props.mode === "filter" && !this._isDragging)
+      if (this._isDragging) {
+        if (this.props.mode === "filter") {
           this._emitRange();
+          this._lastLiveEmit = Date.now();
+        }
+        return;
+      }
+      this._snapToCenterPill(() => {
+        if (this.props.mode === "filter" && !this._isDragging) {
+          this._emitRange();
+        }
       });
-    }, 200);
+    }, 150);
   }
 
   _emitRange() {

--- a/frontend/src/pages/public/MapPage.js
+++ b/frontend/src/pages/public/MapPage.js
@@ -191,11 +191,22 @@ export default class MapPage extends Component {
 
   async _onTimelineRangeChange({ from, to }) {
     const hasRange = from !== undefined && to !== undefined;
+    const rangeStr = hasRange ? (from === to ? String(from) : `${from}-${to}`) : null;
+    
+    // Skip redundant updates if the range hasn't actually changed.
+    if (this._currentRange) {
+        const currentStr = this._currentRange.from === this._currentRange.to 
+            ? String(this._currentRange.from) 
+            : `${this._currentRange.from}-${this._currentRange.to}`;
+        if (rangeStr === currentStr) return;
+    } else if (!hasRange) {
+        return;
+    }
+
     this._currentRange = hasRange ? { from, to } : null;
     this._headerChild?.setProps({ breadcrumb: this._buildBreadcrumb() });
 
     if (hasRange) {
-      const rangeStr = from === to ? String(from) : `${from}-${to}`;
       history.replaceState(null, "", `/map/${rangeStr}`);
     }
     const params = hasRange ? { year_from: from, year_to: to } : {};

--- a/frontend/src/pages/public/TagPage.js
+++ b/frontend/src/pages/public/TagPage.js
@@ -401,6 +401,9 @@ export default class TagPage extends Component {
     const slug = this.props.params?.slug || "";
 
     const timelineParam = from === to ? `${from}` : `${from}-${to}`;
+    const currentTimeline = new URLSearchParams(location.search).get("timeline");
+    if (currentTimeline === timelineParam) return;
+
     const url = new URL(location.href);
     url.searchParams.set("timeline", timelineParam);
     url.searchParams.delete("page");

--- a/frontend/test/Timeline.test.js
+++ b/frontend/test/Timeline.test.js
@@ -1,0 +1,144 @@
+import { test, describe, before, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+describe('Timeline Component', () => {
+  let Timeline;
+  let container;
+  let props;
+
+  before(async () => {
+    // Mock global dependencies
+    global.document = {
+      createElement: (tag) => {
+          if (tag === 'canvas') {
+              return { getContext: () => ({ measureText: () => ({ width: 50 }) }), font: '' };
+          }
+          return {
+            appendChild: () => {},
+            remove: () => {},
+            classList: { add: () => {}, remove: () => {}, toggle: () => {} },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            querySelector: () => null,
+            querySelectorAll: () => [],
+            dataset: {},
+            style: {},
+            setAttribute: () => {},
+            getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 100 }),
+            children: []
+          };
+      },
+      head: { appendChild: () => {} },
+      body: { appendChild: () => {}, classList: { remove: () => {} } },
+      documentElement: { dataset: { theme: 'light' } },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      activeElement: null
+    };
+    global.window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      matchMedia: () => ({ matches: false }),
+      scrollY: 0,
+      innerWidth: 1024,
+      performance: { now: () => Date.now() },
+      requestAnimationFrame: (cb) => setTimeout(cb, 16),
+      cancelAnimationFrame: (id) => clearTimeout(id)
+    };
+    global.ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+
+    // Mock API
+    // (Skipping direct assignment to read-only module export)
+
+    const mod = await import('../src/components/public/Timeline.js');
+    Timeline = mod.Timeline;
+  });
+
+  beforeEach(() => {
+    container = {
+      querySelector: (selector) => {
+          if (selector === '.timeline-track') return { clientWidth: 1000 };
+          if (selector === '.timeline-track-wrapper') return { 
+              addEventListener: () => {},
+              getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 100 }),
+              classList: { add: () => {}, remove: () => {} }
+          };
+          return {
+              appendChild: () => {},
+              innerHTML: '',
+              children: []
+          };
+      },
+      querySelectorAll: () => []
+    };
+    props = {
+        mode: 'filter',
+        onRangeChange: () => {}
+    };
+  });
+
+  test('should emit range change while dragging if mode is filter', (t, done) => {
+    const timeline = new Timeline(container, props);
+    timeline.state.isLoading = false;
+    timeline.state.pills = [
+        { year: 2020, name: '2020', slug: '2020', post_count: 1 },
+        { year: 2021, name: '2021', slug: '2021', post_count: 1 },
+        { year: 2022, name: '2022', slug: '2022', post_count: 1 }
+    ];
+    timeline.state.extent = { min: 2020, max: 2022 };
+    timeline.state.zoom = 1;
+    timeline.state.panX = 0;
+    // Mock getX and lastCollision so emitRange works
+    timeline._getX = (y) => 500;
+    timeline._lastCollision = { visible: timeline.state.pills, clusters: [] };
+
+    let emitted = false;
+    timeline.props.onRangeChange = () => { emitted = true; };
+
+    timeline._isDragging = true;
+    timeline._debounceEmitRange();
+
+    setTimeout(() => {
+        try {
+            assert.strictEqual(emitted, true, 'Should emit even while dragging');
+            done();
+        } catch (e) {
+            done(e);
+        }
+    }, 300);
+  });
+
+  test('should throttle live updates during drag', (t, done) => {
+    const timeline = new Timeline(container, props);
+    timeline.state.isLoading = false;
+    timeline.state.pills = [
+        { year: 2021, name: '2021', slug: '2021', post_count: 1 }
+    ];
+    timeline.state.extent = { min: 2021, max: 2021 };
+    timeline._getX = () => 500;
+    timeline._lastCollision = { visible: timeline.state.pills, clusters: [] };
+
+    let emittedCount = 0;
+    timeline.props.onRangeChange = () => { emittedCount++; };
+
+    timeline._isDragging = true;
+    
+    // Call multiple times rapidly
+    timeline._debounceEmitRange(); // 1st call (immediate live emit)
+    timeline._debounceEmitRange(); // 2nd call (throttled)
+    timeline._debounceEmitRange(); // 3rd call (throttled)
+
+    setTimeout(() => {
+        try {
+            // Should have 1 from immediate live emit, and 1 from the final debounce timeout
+            assert.strictEqual(emittedCount, 2, 'Should throttle to 2 emissions (1 live + 1 final)');
+            done();
+        } catch (e) {
+            done(e);
+        }
+    }, 300);
+  });
+});


### PR DESCRIPTION
This PR enables map pin refreshing while the user is dragging or zooming the timeline, without requiring them to release the mouse/tap.

- Implemented throttled live refresh in Timeline.js (100ms throttle, 150ms debounce).
- Added redundant range check in MapPage and TagPage to avoid unnecessary API calls.
- Added unit tests for Timeline component live refresh logic.