### PR TITLE
Instagram fix scopes (#207)

### DIFF
--- a/api/internal/api/instagram.go
+++ b/api/internal/api/instagram.go
@@ -60,7 +60,7 @@ func (h *InstagramHandler) Connect(c echo.Context) error {
 		"client_id":     {appID},
 		"redirect_uri":  {appURL + "/api/instagram/callback"},
 		"state":         {state},
-		"scope":         {"instagram_basic,instagram_content_publish"},
+		"scope":         {"instagram_business_basic,instagram_business_content_publish"},
 		"response_type": {"code"},
 	}
 	return c.Redirect(http.StatusFound, "https://www.facebook.com/dialog/oauth?"+params.Encode())


### PR DESCRIPTION
* fix(instagram): update OAuth scopes to new Meta Instagram Business API

instagram_basic and instagram_content_publish were deprecated; replace with instagram_business_basic and instagram_business_content_publish.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / infrastructure

## Test plan

- [ ] `./scripts/run-tests.sh` passes
- [ ] Manually tested the affected feature

## Notes for reviewers

<!-- Anything specific to call out or highlight? -->
