### PR TITLE
docs: Timeline control best-in-class UX proposal (point-krcu)

### DIFF
--- a/docs/features/admin-ux-proposal.md
+++ b/docs/features/admin-ux-proposal.md
@@ -1,0 +1,475 @@
+# Admin Frontend (`/light`) — Best-in-Class UX Proposal
+
+UX proposal for the admin frontend, desktop and mobile. Proposal only — no
+implementation. Tracked under beads issue **point-krcu**, companion to the
+[Public UX proposal](public-ux-proposal.md) and the
+[Timeline proposal](timeline-ux-proposal.md).
+
+## Background
+
+The admin is a client-side SPA under `/light` with a fixed left sidebar
+(`frontend/src/components/light/LightSidebar.js`) listing **ten flat nav
+items**: Dashboard, Posts, Media, Tags, Analytics, Menu, Themes, Settings,
+Security, System. Pages live in `frontend/src/pages/light/`; the heavy ones
+are PostEditPage (1305 lines), PostsListPage (773), TagsManagerPage (1158),
+and the shared MediaBrowser component (786).
+
+A lot of strong machinery already exists: 30 s debounced autosave + Ctrl+S,
+window-wide drag-and-drop upload, a Web Share Target queue (post photos from
+the phone share sheet), per-field AI fill buttons, an offline op queue with a
+sync pill, Text/Visual editor modes, a textarea maximizer, `headerCompact.js`
+(buttons collapse to icons when the title would collide), and a folder-tree
+media library reused as a picker. The gaps are **hierarchy and platform fit,
+not features**:
+
+1. **Everything has equal weight.** The daily job — write a post, drop in
+   photos, tag it, publish — sits in the same flat nav as Migrations and
+   Session Management. The editor header shows Delete / Preview link /
+   Analyze / Save / Cancel as five near-equal buttons; the form shows slug,
+   excerpt, schedule, and featured before you reach the content. Dashboard
+   greets you with stat cards, not with "write".
+2. **Saving is two competing models.** Autosave runs silently every 30 s
+   (drafts), while a manual Save button and a status `<select>` carry the
+   real state transitions. Nothing tells you whether your work is safe, and
+   "publishing" is a dropdown mutation, not an action.
+3. **Mobile is a shrunken desktop.** One breakpoint ladder
+   (`css/light/responsive.css`: 64/48/40/30 em) moves the sidebar behind a
+   hamburger and stacks things, but: the posts table keeps its two-row
+   `<table>` layout, the tags tree silently *removes* capability on phones
+   (drag handles and flag buttons are `display:none` at 40 em with no
+   replacement), modals stay modals, and there are no `pointer: coarse` or
+   `orientation` queries. Bottom of the screen — the thumb zone — is unused.
+4. **Wide screens get a centered 1400 px strip.** `--content-max-width:
+   87.5rem` with no use of the remaining glass at 21:9/32:9 — while the
+   editor is exactly the page that could show a live preview beside the form.
+5. **The tag workflow splits across three disconnected surfaces.** TagsInput
+   autocompletes flat names with no hierarchy context and silently creates
+   new root tags; TagsManager is where structure lives, but reordering is
+   drag-only (impossible on touch) and new tags born in the editor land
+   unparented with no queue to file them; the posts list can't filter by tag
+   at all (the tag manager's count badge deep-links to
+   `/light/posts?search=<slug>` — a text-search hack).
+6. **Small duplications add noise.** Theme toggle exists twice (sidebar
+   footer *and* header); Dashboard stat cards duplicate Analytics; every
+   page hand-rolls its own `light-layout` markup instead of using
+   `AdminLayout.js`, so chrome drifts (Dashboard re-implements the sync
+   pill).
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Two complexity layers | **Progressive disclosure in one app**, not two apps/modes: a compose-first daily layer (Home, editor essentials, primary nav) over a full Manage layer (grouped nav, Details rail, full pages) | A "simple/advanced" mode switch creates two UIs to learn and a setting to forget; disclosure keeps one mental model |
+| Daily layer scope | Posting + managing **posts / photos / tags** only | Matches the stated main goal; everything else is fine-tuning |
+| Save model | **Autosave is the only save** (with a visible state chip); the primary button is **Publish / Update** (split: now / schedule) | One model instead of two; "is my work safe?" always answered; publishing becomes a deliberate verb |
+| Phone navigation | **Bottom tab bar** (Home · Posts · Media · Tags · Manage), editor goes full-screen over it | Thumb-zone navigation; hamburger drawer demoted to the Manage tab |
+| Wide screens | Editor gains a **live preview pane** ≥ ~112 em; other pages cap and center | Preview is the one admin surface that earns the glass; tables/forms must not stretch |
+| Tag model | **Assign in the editor, curate in the Manager**, with a bridge: hierarchy-aware autocomplete + an "Unfiled" queue | Each surface gets one job; new-tag debt becomes visible instead of silent |
+
+## Design principles
+
+1. **The next post is always one action away.** From any screen, on any
+   device: one tap/click to a ready editor.
+2. **Frequency earns proximity.** Daily actions sit in the first visual
+   layer; weekly ones one step away; rare ones (migrations, sessions) are
+   findable but never in the way.
+3. **Never lose work, always say so.** Autosave everywhere, and its state is
+   visible (saved / saving / offline-queued) at all times.
+4. **No capability cliffs between devices.** Everything possible on desktop
+   is possible on a phone — the *gesture* may differ (Move dialog instead of
+   drag), the capability may not vanish.
+5. **Tags are one vocabulary.** The same tag, with the same hierarchy
+   context, in the editor, the posts list, and the manager.
+
+## Proposed design
+
+### A. Information architecture — the two layers
+
+**A1. Nav groups.** Replace the ten-item flat list in `LightSidebar.js` with
+two groups:
+
+```
+WRITE  (layer 1)            MANAGE  (layer 2, collapsible)
+  ✎ New post  ← button        Analytics
+  Home                        Menu
+  Posts                       Themes
+  Media                       Settings
+  Tags                        Security
+                              System
+```
+
+"New post" becomes a real button at the top of the sidebar (not just a
+header action on two pages). The Manage group renders collapsed by default
+(persisted in localStorage), expanded while any of its pages is active. No
+pages are deleted — Security and System stay exactly as they are, one click
+deeper in visual weight only.
+
+**A2. Home = compose-first.** DashboardPage becomes Home:
+
+- Top: a **compose strip** — "What's new?" title field + photo drop zone;
+  typing or dropping navigates into the full editor with content carried
+  over (the Web Share Target flow already proves the pattern).
+- Middle: **Continue writing** — up to 5 most recent drafts/scheduled posts
+  with thumbnail, title, autosave age. This is the real daily resume point.
+- Bottom: a compact health row — storage bar (only when > 70 %), sync pill,
+  version banner. The stat cards and Top Posts table move to Analytics,
+  which already owns that data (`getPostAnalytics`, `getTopPosts` are
+  fetched by both pages today).
+
+**A3. One layout component.** All pages adopt `AdminLayout.js` instead of
+duplicating `light-layout` markup (PostEditPage, PostsListPage,
+TagsManagerPage, DashboardPage all hand-roll it today). Engineering enabler
+for everything below: bottom bar, autosave chip, and header behavior get
+implemented once. Remove the duplicate theme toggle (keep the sidebar/Manage
+one; on phones it lives in the Manage tab).
+
+### B. Navigation per device
+
+| Device | Primary nav | Manage layer |
+|---|---|---|
+| Phone portrait | **Bottom tab bar**: Home · Posts · ➕ (center, prominent) · Media · ⋯ More | "More" tab opens a sheet: Tags, Analytics, Menu, Themes, Settings, Security, System, theme toggle, view-site, logout |
+| Phone landscape | Same bottom bar (it's short); header drops the title row | same |
+| Tablet portrait | **Icon rail** (~64 px): logo, ✎, 5 icons + Manage chevron; labels in tooltips | Manage chevron expands rail in place |
+| Tablet landscape & desktop | Full 240 px sidebar (A1) | collapsed group |
+| Desktop, user-collapsed | Sidebar collapses to the same icon rail (toggle persisted) | chevron |
+
+The hamburger + slide-over drawer (`_setupMobileToggle` in
+`LightSidebar.js`) is removed on phones in favor of the bottom bar — the
+drawer pattern hides navigation behind a tap and occludes content; tabs are
+one tap and always visible. The editor and any open sheet cover the bottom
+bar (full-screen compose). Tags moves into "More" on phones only because the
+center slot goes to ➕ New post; on rail/sidebar it stays first-layer.
+
+### C. The editor — distraction-free core + Details
+
+**C1. The core is three fields.** What stays on the canvas: **title**,
+**content** (Visual/Text toggle as today), **tags**. Everything else —
+slug row, excerpt, featured star, schedule row, immersive mode, custom CSS,
+Instagram — moves into a **Details** surface. The `advanced-options-details`
+disclosure already exists for the last three; this finishes the thought.
+
+**C2. Details = right rail on wide, sheet on narrow.** ≥ 64 em: a 320 px
+right rail, toggled by a "Details" header button, open state persisted.
+< 64 em: the same content as a bottom sheet. Order: Status & visibility
+(incl. featured + schedule), Slug, Excerpt (+ AI), Immersive mode, Custom
+CSS, Instagram. Each section a collapsible group with a one-line summary
+when closed (e.g. "Slug · `my-trip`", "Excerpt · auto") so the rail reads as
+a checklist, not a wall of forms.
+
+**C3. Publish model.** The editor header becomes:
+
+```
+←  Trip to Lisbon            ✓ Saved · 12s ago     [⋯]  [Publish ▾]
+```
+
+- **Autosave chip** replaces the Save button. States: `Saving…` →
+  `✓ Saved · Xs ago` → `⚠ Offline — queued` (wired to the existing
+  `offline_status` store) → `⚠ Save failed — retry`. `aria-live="polite"`.
+  Autosave debounce drops from 30 s to ~5 s after idle; Ctrl+S stays as
+  "save now".
+- **Primary button is contextual**: drafts get `Publish ▾` (split: Publish
+  now / Schedule… / Mark hidden); published posts get `Update` plus an
+  `Unpublish` item in the menu. The raw status `<select>` moves to Details
+  for the rare states (`page`).
+- **⋯ overflow** holds Delete, Preview link, Analyze (AI fill-all), and
+  View on site. Cancel becomes `←` back (with autosave there is nothing to
+  cancel — leaving is always safe).
+
+**C4. Phone editor = full-screen sheet.** Covers the bottom bar; header is
+`← · saved-chip · Publish`; tags input docks above the keyboard; Details is
+the bottom sheet (C2); the media-add button is a persistent toolbar item
+(window drag-and-drop has no touch equivalent — today phones can only add
+media through the picker inside Visual mode).
+
+**C5. Live preview ≥ ~112 em (21:9 and up).** A toggleable right pane
+rendering the post through the same renderer the public PostPage uses,
+updating on autosave ticks. Form column stays ~720 px for comfortable line
+length; preview takes the remainder (capped ~900 px, centered beyond — see
+G). This is the honest use of ultrawide glass and removes the
+write-save-switch-tab-reload loop entirely.
+
+### D. Posts list
+
+**D1. Filter bar instead of select + search.** Status becomes **segmented
+chips** (`All · Drafts · Published · Scheduled · …` with counts) — one tap,
+visible current state — plus the search field and a **tag filter** chip
+(reusing TagsInput in single-pick mode). Requires `tag=` support on
+`GET /api/posts`; the tag manager's count badge then deep-links properly
+instead of via `?search=`.
+
+**D2. Cards on touch, table on desktop.** The two-`<tr>`-per-post table
+collapses terribly. < 48 em each post renders as a card: thumbnail left,
+title + tag chips + updated date right, status pill top-right; tap = edit;
+swipe-left or long-press = quick actions (status, trash). Select mode and
+the bulk toolbar work on cards identically (long-press enters selection —
+the platform-native pattern).
+
+**D3. Keep the good parts.** Inline per-row status change, select/bulk mode,
+and the trash flow are right; they survive restyled (status pill opens the
+same options as the editor's Publish menu, for one vocabulary).
+
+### E. Media
+
+**E1. Phone capture path.** On `pointer: coarse`, the upload zone becomes
+two explicit buttons — **Take photo** (`capture` input) and **Photo
+library** — plus the existing share-target path. Desktop keeps drag-drop +
+browse.
+
+**E2. Folder tree → breadcrumb + chips on narrow.** The left folder tree
+doesn't fit phones; < 48 em it becomes a breadcrumb (`2026 / 06`) with
+child-folder chips beneath — same data, one-hand navigation. The tree stays
+≥ 48 em.
+
+**E3. Selection parity.** Long-press enters select mode on touch (checkbox
+overlay), matching D2. Grid stays `auto-fill, minmax(…)` so it already
+scales from 2 columns (phone) to many (ultrawide) — just raise the minmax on
+≥ 112 em so thumbnails grow instead of multiplying into a contact sheet.
+
+### F. Tag workflow
+
+The model: **assign** (editor, posts list) vs **curate** (Tags Manager),
+bridged so assignment never silently creates taxonomy debt.
+
+**F1. Hierarchy-aware autocomplete.** TagsInput suggestions show the parent
+path and count: `Lisbon — Travel › Portugal · 12`. Disambiguates duplicates,
+teaches the taxonomy where it's used, costs one API field (the editor
+already loads the tag list for autocomplete).
+
+**F2. Deliberate creation.** When the entered text matches no tag, the
+suggestion list ends with `＋ Create "Alfama"…` opening a 2-field inline
+popover: name + **parent picker** (same autocomplete, optional). Enter-enter
+keeps the fast path (creates unfiled); the parent field makes filing-at-birth
+one keystroke away instead of a trip to the Manager.
+
+**F3. The Unfiled queue.** Tags Manager gets a pinned **Unfiled (N)** group
+at the top of the tree listing parentless, non-system tags (today they're
+invisible unless you notice them at root level). Each row: file-under
+(parent picker), merge-into, delete. This turns F2's fast path into visible,
+batchable debt — the missing bridge between assigning and curating.
+
+**F4. No capability cliffs in the Manager.** Every drag affordance gets a
+dialog twin: a **Move…** action (new parent + position) on each row — which
+also fixes phones, where `tm-drag-handle` is hidden today with no
+replacement. The flags row (hidden at 40 em) folds into the existing tag
+editor modal instead of disappearing. Tree rows get ≥ 44 px touch targets.
+
+**F5. Merge tags.** `Merge into…` action (Manager + Unfiled queue): re-tags
+all posts, optionally keeps the loser as a redirect. Today cleaning up
+`lisboa`/`Lisbon` duplicates is manual post-by-post editing — the single
+most painful taxonomy chore.
+
+**F6. One tag chip everywhere.** Posts-list tag chips, TagsInput badges, and
+Manager rows share one component: click filters the posts list by that tag
+(D1), and a small `›` affordance opens the same family popover the public
+proposal defines (B2 there) showing ancestors/children.
+
+### G. Layout & responsive matrix
+
+| Class | Query | Layout |
+|---|---|---|
+| Phone portrait | ≤ 40 em | Bottom tab bar; cards not tables; modals → bottom sheets; editor full-screen |
+| Phone landscape | ≤ 48 em and `orientation: landscape` | Bottom bar stays; single-row header (no title row); editor hides chrome except `← · chip · Publish` |
+| Tablet portrait | 40–64 em | Icon rail; content single column; Details as overlay sheet |
+| Tablet landscape | 48–80 em | Full sidebar; posts table returns; Details rail overlays |
+| Desktop 16:9 | 80–112 em | Sidebar + content (max 87.5 rem); Details rail inline (push, not overlay) |
+| Ultrawide 21:9 | ~112–160 em | Editor: form + live preview split (C5). Other pages: content stays capped and **left-anchored next to the sidebar** (no center-strip orphaning) |
+| Super-ultrawide 32:9 | > 160 em | Same as 21:9 with preview capped ~900 px; remaining space stays margin — admin forms must never stretch |
+| Touch | `pointer: coarse` (any width) | ≥ 44 px targets; no hover-only actions (row actions always visible at low opacity); long-press = select/quick-actions; no drag-only features (F4) |
+
+All current hover-revealed affordances (table row action buttons, media item
+overlays, tree-row actions) get the same treatment as the public proposal's
+D4: always rendered on coarse pointers.
+
+### H. Cross-cutting
+
+- **Command palette (Ctrl+K / ⌘K)**: jump to any post by title, any tag,
+  any admin page; actions ("New post", "Open settings › Instagram"). This
+  is the power-user escape hatch that makes the calm layer-1 nav acceptable
+  to experts — depth without visual cost.
+- **Keyboard map**: `Ctrl+S` save-now (exists), `Ctrl+Enter` publish/update,
+  `Ctrl+K` palette, `/` focuses list search, `n` new post from lists. A `?`
+  overlay documents them.
+- **Accessibility**: autosave chip `aria-live`; bottom bar = `<nav>` with
+  `aria-current`; sheets/rails are `role="dialog"` focus traps that return
+  focus; tree keyboard-navigable (arrows expand/collapse — the roving
+  tabindex the tree lacks today); `prefers-reduced-motion` skips
+  sheet/rail/tab transitions.
+
+### Add / remove summary
+
+**Add:** nav grouping + sidebar New-post button (A1) · compose-first Home
+(A2) · bottom tab bar (B) · autosave chip + Publish split-button (C3) ·
+Details rail/sheet (C2) · live preview ≥ 21:9 (C5) · posts tag filter +
+status chips (D1) · phone cards + long-press select (D2) · phone capture
+buttons (E1) · hierarchy-aware tag autocomplete + create popover (F1/F2) ·
+Unfiled queue (F3) · Move…/Merge… dialogs (F4/F5) · command palette (H).
+
+**Remove / simplify:** manual Save button and the save/autosave dual model
+(C3) · status `<select>` as primary control (→ Details; rare states only) ·
+Dashboard stat cards + Top Posts (→ Analytics, A2) · hamburger drawer on
+phones (→ bottom bar, B) · duplicate theme toggle (A3) · slug/excerpt/
+featured/schedule from the editor canvas (→ Details, C1) · `?search=<slug>`
+tag deep-link hack (D1) · hidden-on-mobile drag handles & flag buttons as a
+"responsive strategy" (F4) · per-page hand-rolled layout markup (A3).
+
+## Mockups
+
+### Desktop 16:9 — editor, Details rail open
+
+```
+┌──────────┬──────────────────────────────────────────────┬───────────────┐
+│ ✎ New    │ ←   ✓ Saved · 8s        [⋯]  [ Publish ▾ ]   │ DETAILS       │
+│          ├──────────────────────────────────────────────┤ ▸ Status      │
+│ Home     │  Trip to Lisbon                          ⌁AI │   draft ★     │
+│ Posts ◀  │  ───────────────────────────────────────     │ ▸ Slug        │
+│ Media    │  [travel ×] [portugal ×] [lisbon ×] + tag    │   trip-to-…   │
+│ Tags     │  ┌────────────────────────────────────────┐  │ ▸ Excerpt     │
+│          │  │  Text | Visual                         │  │   auto    ⌁AI │
+│ MANAGE ▸ │  │                                        │  │ ▸ Immersive   │
+│          │  │   /2026/06/alfama.jpg   [img]          │  │   auto        │
+│          │  │   Morning in Alfama…                   │  │ ▸ Custom CSS  │
+│ ◐  ↗  ⎋ │  │                              [+ media] │  │ ▸ Instagram   │
+└──────────┴──────────────────────────────────────────────┴───────────────┘
+  sidebar: WRITE group + collapsed MANAGE      canvas: title·tags·content only
+```
+
+### Ultrawide 21:9 — editor with live preview
+
+```
+┌────────┬────────────────────────────┬──────────────────────────┬────────┐
+│ rail/  │ ←  ✓ Saved   [⋯][Publish▾] │  LIVE PREVIEW            │        │
+│ side-  │  Trip to Lisbon            │  ┌────────────────────┐  │ margin │
+│ bar    │  [travel ×][lisbon ×]      │  │  rendered as the   │  │ (32:9: │
+│        │  ┌──────────────────────┐  │  │  public post page, │  │ grows; │
+│        │  │ editor ~720px        │  │  │  updates on auto-  │  │ never  │
+│        │  │                      │  │  │  save  (~900px cap)│  │ wider  │
+│        │  └──────────────────────┘  │  └────────────────────┘  │ forms) │
+└────────┴────────────────────────────┴──────────────────────────┴────────┘
+```
+
+### Phone portrait — Home and editor
+
+```
+   HOME                          EDITOR (full-screen, covers tab bar)
+┌─────────────────────┐        ┌─────────────────────┐
+│ Point        ⟳ sync │        │ ←   ✓ Saved   Publish│
+├─────────────────────┤        ├─────────────────────┤
+│ ┌─────────────────┐ │        │ Trip to Lisbon      │
+│ │ What's new?     │ │  tap   │ [travel ×][+ tag]   │
+│ │ ✎ … or 📷 drop  │ │  ───►  │ ┌─────────────────┐ │
+│ └─────────────────┘ │        │ │ content         │ │
+│ CONTINUE WRITING    │        │ │                 │ │
+│ ▤ Alfama draft · 2h │        │ ├─────────────────┤ │
+│ ▤ Sintra  sched·Fri │        │ │ 📷 add · Details │ │ ← toolbar
+│ storage ▓▓▓░ 78%    │        │ └──[keyboard]─────┘ │
+├─────────────────────┤        └─────────────────────┘
+│  ⌂   ▤   ➕   ▣   ⋯ │ ← bottom tab bar              Details = bottom sheet
+│ Home Posts New Media│   (More: Tags, Analytics, …)
+└─────────────────────┘
+```
+
+### Phone portrait — posts as cards + long-press
+
+```
+┌─────────────────────┐
+│ Posts            ⌕  │
+│ (All 24)(Drafts 3)… │ ← status chips, swipe-scroll
+├─────────────────────┤
+│ ┌───┬─────────────┐ │
+│ │img│ Trip to Li… │ │  tap = edit
+│ │   │ [travel] 2h │●│  long-press = select mode
+│ └───┴─────────────┘ │  swipe ← = status / trash
+│ ┌───┬─────────────┐ │
+│ │img│ Sintra      │ │
+│ └───┴─────────────┘ │
+├─────────────────────┤
+│  ⌂   ▤   ➕   ▣   ⋯ │
+└─────────────────────┘
+```
+
+### Tablet portrait — icon rail; Tags Manager with Unfiled queue
+
+```
+┌───┬───────────────────────────────────┐
+│ ✎ │ Tags                 [Tree|List] +│
+│ ⌂ │ ┌───────────────────────────────┐ │
+│ ▤ │ │ ⚠ UNFILED (3)                 │ │ ← pinned queue
+│ ▣ │ │  alfama   [File under…][Merge]│ │
+│ # │ │  sintra…  [File under…][Merge]│ │
+│ ⋯ │ ├───────────────────────────────┤ │
+│   │ │ ▾ Travel · 48        [⋯ Move…]│ │ ← every row: 44px,
+│   │ │   ▾ Portugal · 12    [⋯]      │ │   Move…/Merge…/Edit
+│   │ │     Lisbon · 9       [⋯]      │ │   (no drag-only ops)
+└───┴───────────────────────────────────┘
+```
+
+## Prioritized roadmap (task breakdown)
+
+**P0 — the daily layer (highest leverage, mostly restructuring)**
+
+1. Adopt `AdminLayout` on all pages; single theme toggle; shared header
+   behaviors (A3) — *enabler for everything below*
+2. Sidebar: WRITE/MANAGE groups + New-post button; collapsed-state
+   persistence (A1)
+3. Editor canvas reduction: move slug, excerpt, featured, schedule into a
+   Details disclosure (C1; rail/sheet polish comes in P1)
+4. Autosave chip + Publish/Update split-button; retire manual Save; demote
+   status select (C3)
+5. Phone bottom tab bar; remove hamburger drawer ≤ 48 em (B)
+6. Posts list as cards < 48 em with always-visible actions (D2)
+7. Touch pass: ≥ 44 px targets, no hover-only controls, `pointer: coarse`
+   styles (G)
+
+**P1 — the manage layer & tags**
+
+8. Details right rail (≥ 64 em, persistent) / bottom sheet (< 64 em) with
+   section summaries (C2)
+9. Tag autocomplete with parent paths + counts (F1)
+10. Create-tag popover with inline parent picker (F2)
+11. Tags Manager: Unfiled queue (F3)
+12. Tags Manager: Move… dialog; flags into editor modal; 44 px tree rows (F4)
+13. Merge tags (API + UI) (F5)
+14. Posts list: status chips + tag filter; `tag=` param on `GET /api/posts`;
+    fix the `?search=` deep link (D1)
+15. Home: compose strip + Continue-writing list; stats move to Analytics (A2)
+16. Media on phones: capture/library buttons, breadcrumb + folder chips,
+    long-press select (E1–E3)
+17. Tablet icon rail + desktop sidebar collapse toggle (B)
+18. Phone-landscape compact chrome (G)
+
+**P2 — wide screens & power use**
+
+19. Live preview pane ≥ 112 em, autosave-driven (C5)
+20. Ultrawide caps: left-anchored content, preview cap, media minmax bump
+    (G, E3)
+21. Command palette (H)
+22. Keyboard map + `?` overlay; `Ctrl+Enter` publish (H)
+23. Quick-actions swipe on post cards (D2)
+24. Tag chip unification + family popover shared with public frontend (F6)
+25. Accessibility sweep: aria-live chip, focus traps, tree roving tabindex,
+    reduced-motion (H)
+
+## Considered and rejected
+
+- **A separate "simple mode" toggle** (two switchable UIs): doubles every
+  future design decision, and the user must discover and manage the mode
+  itself; progressive disclosure gives the same calm without a fork.
+- **Moving rare pages (Security/System) into a settings mega-page with
+  tabs**: churns working pages for cosmetic gain; nav grouping (A1) buys
+  the same calm for a fraction of the cost.
+- **WYSIWYG/block editor rewrite**: the Visual/Text node model
+  (`parseNodes`/`serializeNodes`) fits this content format (image sequences
+  + text blocks) well; the problem is around the editor, not in it.
+- **Floating action button (FAB) for New post on phones**: occludes content
+  and collides with the editor toolbar; the dedicated center tab slot is
+  always in the same place and never covers anything.
+- **Infinite scroll for posts/media lists**: same verdict as the public
+  proposal — pagination is URL-addressable and predictable; admin lists are
+  worked, not browsed.
+- **Three-pane master-detail (list | editor | preview) at 32:9**: tested
+  against principle 2 — editing-while-listing is a rare workflow that costs
+  a third navigation model; the editor preview split (C5) plus fast
+  back/forward covers it.
+- **Autosave for *published* posts writing live**: dangerous — edits to a
+  published post autosave to a revision/pending state and go live only on
+  "Update"; the chip says `Edited — not yet live` (folded into C3's design).

--- a/docs/features/public-ux-proposal.md
+++ b/docs/features/public-ux-proposal.md
@@ -1,0 +1,427 @@
+# Public Frontend — Best-in-Class UX Proposal
+
+Sitewide UX proposal for the public (visitor-facing) frontend, desktop and
+mobile. Proposal only — no implementation. Tracked under beads issue
+**point-krcu**, companion to the
+[Timeline proposal](timeline-ux-proposal.md), which owns all
+timeline-control-specific decisions.
+
+## Background
+
+The public site is a client-side SPA with seven routes: `/` (HomePage),
+`/posts/:slug` (PostPage), `/tags` (TagsPage), `/tags/:slug` (TagPage),
+`/map[/:year]` (MapPage), `/search` (SearchPage), `/preview/:token`
+(PreviewPage) — all under `frontend/src/pages/public/`. Shared chrome lives in
+`frontend/src/components/public/`: PublicHeader (branding, breadcrumb, tag
+bar, action icons), PublicHeaderTagsBar (root-tag chips with dropdowns),
+PostGrid/PostCard, PostContent (normal + immersive carousel), Timeline,
+TagCloud, PublicFooter (pagination or immersive EXIF/tags), MediaLightbox.
+
+A lot is already best-in-class material: a coherent design-token system
+(`frontend/css/common/tokens.css`), em-based breakpoints, safe-area insets,
+disciplined `touch-action`, lazy-loaded page modules, rubber-band swipe
+pagination, a progressive header fold with hamburger fallback, and a
+theme system with proper dark mode. The gaps are **consistency and
+legibility**, not engineering:
+
+1. **Tags behave differently everywhere.** A pill on a post needs *two*
+   clicks (first opens an ancestor flyout, second navigates —
+   `frontend/src/utils/tags.js`); a header chip opens a *children* dropdown
+   on first click and navigates only on a re-click within 300 ms
+   (`PublicHeaderTagsBar.js`); the tag cloud does the flyout dance again.
+   Three surfaces, three interaction models, none of them
+   "click = go". Worse, `min_tag_posts_to_show` hides tags from tag pages
+   while their pills still render on posts — clicking one 404s.
+2. **Components don't share one filter language.** Active tag, timeline
+   range, search query, and page are four separate mechanisms. The URL
+   *almost* models them (`/tags/travel?timeline=2023-2024&page=2`), but
+   nothing displays the combined state, search can't be scoped to a tag,
+   search doesn't match tag names at all, and the only "reset" is editing
+   the URL.
+3. **Ultrawide screens get a 1200 px column.** `--content-max-width: 75rem`
+   leaves ~680 px dead per side at 21:9 and ~1120 px at 32:9; the post grid
+   never exceeds ~3 columns no matter how much glass is available.
+4. **Touch is desktop-shrunk.** Tag pills are 32 px tall, header buttons
+   40 px (44 px is the floor); there are no `pointer: coarse` or
+   `orientation` queries; card edit buttons and dropdown affordances are
+   hover-only.
+5. **Some flows dead-end.** No share/copy-link anywhere; immersive mode is
+   auto-detected with no visible way out other than Esc; search has no
+   suggestions; a failed map fetch renders an empty map silently.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Component communication | **URL is the single source of truth** for `tag × years × query × page`; components read/write it through one shared context, never talk to each other directly | Predictable, deep-linkable, back-button-correct; kills component-pair special cases |
+| Tag interaction | **One click/tap = navigate.** Ancestors/children move to a hover-intent flyout (desktop) and long-press sheet (touch) | The two-click pattern is undiscoverable and punishes the 95 % case (just go) to serve the 5 % case (browse hierarchy) |
+| Ultrawide strategy | Grid container grows to **~1800 px** (more columns via existing `auto-fill`); reading column stays 800 px; map and immersive go full-bleed | Use the glass for *more content*, never for *wider text lines* |
+| Pagination | **Keep pages, no infinite scroll**; keep swipe gestures | URL-addressable, footer stays reachable, predictable position |
+| Tag surfaces | Each surface gets one job: header bar = *sections*, breadcrumb = *where am I*, pills = *what is this post*, tag cloud → replaced by an **Explore block** | Today three surfaces compete to be "the" tag navigation |
+
+## Design principles
+
+1. **The URL is the interface.** Every view state a visitor can reach —
+   tag, year range, query, page, slide — is in the URL, restorable, and
+   shareable. Back always means "where I just was".
+2. **One mental model for tags.** A tag looks the same, clicks the same,
+   and reveals its hierarchy the same way on every surface.
+3. **Click is for going, hover/long-press is for peeking.** No primary
+   action ever hides behind a second click or a hover-only control.
+4. **Content leads, chrome recedes.** The header earns its height; filters
+   appear only when active; empty space on big screens is filled with
+   content, not decoration.
+5. **Every screen is a first-class screen.** Phone landscape, tablet, and
+   32:9 are designed states, not side effects of min/max-width math.
+
+## Proposed design
+
+### A. Unified filter context (the communication contract)
+
+**A1. One context object, URL-backed.** Define a tiny shared module
+(`frontend/src/utils/viewContext.js`-style) owning
+`{ tag, years, query, page }` parsed from / serialized to the URL:
+
+```
+/                       → { }
+/tags/travel            → { tag: travel }
+/tags/travel?timeline=2023-2024&page=2
+                        → { tag: travel, years: [2023,2024], page: 2 }
+/search?q=lisbon&tag=travel
+                        → { query: lisbon, tag: travel }
+```
+
+Pages render from the context; Timeline, header tag bar, search, and
+pagination *request* context changes (replace/merge) and re-render on the
+resulting URL change. No component holds private filter state, no
+component calls another. This is the "predictable communication" rule:
+**emit context change → router → everyone re-reads**.
+
+**A2. Filter chips row.** When the context is non-default, a single slim
+row appears between header and content showing each active facet as a
+removable chip, plus "Clear all":
+
+```
+Travel ×   2023 – 2024 ×   “lisbon” ×          Clear all · 23 posts
+```
+
+This makes the combined state readable (today the timeline range is only
+visible inside the timeline control), gives every facet an obvious undo,
+and shows the result count. On HomePage with no filters the row doesn't
+exist — zero idle cost. The chip row is the *only* new chrome this
+proposal adds to every page.
+
+**A3. Scoped search.** The header search submits within the current
+context: searching from `/tags/travel` produces
+`/search?q=…&tag=travel` with the tag chip pre-set (removable). The
+search API gains a `tag` filter param; this is the bridge between the
+two currently disconnected discovery systems.
+
+**A4. Search knows tag names.** `/api/posts?q=` (or a sibling endpoint)
+also matches tag names; SearchPage shows a compact "Tags" strip above
+post results ("**lisbon** — tag · 5 posts → /tags/lisbon"). Searching
+for a place a visitor saw as a pill must find it.
+
+### B. Tag workflow
+
+**B1. One click = navigate, everywhere.** Pills on posts/cards, tag cloud
+entries, and header chips all navigate on first activation. Remove the
+two-click ancestor-flyout pattern in `utils/tags.js` and the 300 ms
+re-click rule in `PublicHeaderTagsBar.js`.
+
+**B2. Hierarchy peek = hover intent / long-press.** One flyout component
+(reuse the existing singleton flyout in `utils/tags.js`, restyled) serves
+every surface and shows the *full* family: ancestor chain above, children
+below, each with post counts:
+
+```
+        World › Europe › Portugal        ← ancestors (links)
+        ┌──────────────────┐
+        │  Lisbon · 5      │             ← the tag itself (header row)
+        ├──────────────────┤
+        │  Alfama · 2      │             ← children (links)
+        │  Belém · 1       │
+        └──────────────────┘
+```
+
+Desktop: opens after ~250 ms hover on any tag surface. Touch: opens on
+long-press (≥350 ms) as a bottom sheet on phones (< 640 px), anchored
+card on tablets. Header chips keep a dedicated `▾` caret as the visible,
+tappable alternative (principle 3) — caret opens the same flyout, label
+navigates.
+
+**B3. No more tag 404s.** Tags below `min_tag_posts_to_show` either stop
+rendering as pills (preferred — apply the same visibility filter to the
+post payload) or resolve to a normal tag page with an honest empty state
+("Nothing published under *Alfama* yet — see *Lisbon*", linking the first
+visible ancestor). A visible link must never 404.
+
+**B4. Tag page = context page.** `/tags/:slug` keeps its two modes (grid /
+post-in-context) and gains: the filter chips row (A2), description,
+children/related sub-nav as one wrapping pill row under the title, and the
+tag-scoped Timeline it already has. The breadcrumb remains the single
+"where am I" device; drop `in_breadcrumbs` level-skipping for the public
+trail so the path shown always matches the flyout's ancestor chain.
+
+**B5. Tags directory stays.** `/tags` remains the sitemap-style full tree —
+it is the one place exhaustiveness beats curation. Add per-branch
+collapse and an inline filter-as-you-type box (client-side; the payload
+is already full).
+
+### C. Navigation & header
+
+**C1. Keep the fold ladder, make the burger canonical.** The progressive
+fold (`fold-title → fold-nav → fold-tags`, `frontend/css/public/header.css`)
+is the right idea. Specify the order explicitly as: title text → action
+icons collapse into burger → tag bar folds into burger. Inside the burger,
+order is always: search field (focused on open), tag tree, map / all-tags
+/ about links, theme toggle. One predictable home for everything that
+folded.
+
+**C2. Search is always one tap.** The magnifier icon never folds. On
+desktop it expands inline (current behavior); on `pointer: coarse` it
+opens a full-width overlay under the header with the keyboard up,
+suggestions below (F1).
+
+**C3. Footer as quiet sitemap.** Footer keeps pagination as its center
+slot and adds a right-side link set: All tags · Map · About · RSS (if
+enabled). The footer is where "where else can I go?" lives, freeing the
+header to stay minimal.
+
+**C4. Map and Tags get stable entry points.** Today Map is an icon and
+`/tags` is barely linked. With C3 plus the burger (C1), both are always
+reachable within one interaction from any page.
+
+### D. Layout & responsive
+
+**D1. Breakpoint and input matrix.** Keep em-based widths; add the two
+missing axes — pointer type and orientation:
+
+| Class | Query | Layout |
+|---|---|---|
+| Phone portrait | ≤ 32em | 1-col grid, burger header, bottom sheets |
+| Phone landscape | ≤ 48em **and** `orientation: landscape` | 2-col grid, **short header** (compact, title-less), side post-nav hidden |
+| Tablet | 32–64em | 2-col grid, full header |
+| Desktop 16:9 | 64em–~112em | 3-col grid, 1200 px container |
+| Ultrawide 21:9 | ~112em–160em | container grows to ~1800 px → 4–5 cols |
+| Super-ultrawide 32:9 | > 160em | container caps at ~1800 px, **centered**; map/immersive full-bleed |
+| Touch | `pointer: coarse` (any width) | ≥ 44 px targets, long-press flyouts, no hover-only UI |
+
+Implementation is cheap: `--content-max-width: clamp(75rem, 90vw, 112rem)`
+on grid pages plus the existing `auto-fill, minmax(20rem, 1fr)` already
+yields 4–5 columns; nothing else reflows.
+
+**D2. Per-page wide-screen behavior.**
+
+- **Grid pages** (home, tag, search): wider container, more columns; the
+  hero/featured card spans 2 columns instead of full row above 4 columns
+  (a 1700 px full-bleed hero is a billboard, not a card).
+- **Post page**: prose stays at `--content-narrow` (800 px). On ≥ 112em,
+  media inside the post may break out to ~1200 px (`figure` breakout),
+  and post meta (date, tags, EXIF) moves to a sticky side rail beside the
+  text instead of inline — the classic comfortable-reading + wide-margins
+  pattern.
+- **Map**: full-bleed at every width (it's the one page that should eat
+  32:9 whole); controls and popovers stay within safe margins.
+- **Immersive carousel**: already `100vw` — correct; only the info
+  overlay gets a max-width so captions don't span 3440 px.
+
+**D3. Touch targets.** Raise tag pills and header/footer icon buttons to
+≥ 44 px effective size on `pointer: coarse` via hit-slop (pseudo-element
+or padding), keeping visual size; same technique the Timeline proposal
+uses for year pills.
+
+**D4. Hover parity.** Every hover-revealed control gets a touch path:
+card edit button always visible at low opacity on coarse pointers;
+dropdown carets always rendered (B2); flyouts via long-press. Tooltips
+become non-essential (information they carry must exist elsewhere).
+
+### E. Reading & immersive
+
+**E1. Visible mode toggle.** Immersive auto-detection stays, but the post
+view gets a small persistent toggle (⤢ / ☰) to switch between carousel
+and article layout. Auto-detection chooses the default; the visitor gets
+the override. Esc keeps exiting.
+
+**E2. Share / copy link.** One share button on PostPage and in the
+immersive info overlay: native `navigator.share` where available, copy-
+to-clipboard + toast fallback. In immersive mode it shares the current
+slide URL (`#3` hash already exists). This is the single most glaring
+missing feature for a public site.
+
+**E3. Slide progress.** Replace the "3 of 5" counter with thin dot/segment
+indicators (counter stays as accessible text). Tappable on touch,
+clickable on desktop.
+
+**E4. Lightbox and carousel converge.** MediaLightbox and the immersive
+carousel duplicate gesture/keyboard logic; long-term, one media-viewer
+component with two entry modes. (Engineering note, but it guarantees the
+two viewers never drift apart in UX.)
+
+### F. Search
+
+**F1. Typeahead.** As the visitor types (≥ 2 chars, debounced): matching
+tags (with counts) first, then top 3 post-title matches, then "Search
+everything for *q* ↵". Powered by the already-loaded tag index plus one
+lightweight endpoint. Recent searches (localStorage, 5 max) shown on
+focus before typing.
+
+**F2. Honest empty state.** No results → say so, show "Clear filters"
+when chips are active (a scoped search may fail only because of the
+scope), and offer the top-level tag list as escape hatch.
+
+### G. Accessibility & motion
+
+- Filter chips row is an `aria-live="polite"` region: "Showing Travel,
+  2023 to 2024 — 23 posts" announces every context change for free.
+- Flyout/bottom sheet: `role="dialog"`, focus trapped while open,
+  returns to the invoking tag on close; arrow keys traverse entries.
+- Header fold never changes DOM order — tab order is identical folded
+  and unfolded; burger button is `aria-expanded`-correct.
+- `prefers-reduced-motion`: skip carousel slide animation, sheet slide-up,
+  rubber-band, chip enter/exit; instant state changes instead.
+- Map page: fetch failure renders a visible error card with retry — never
+  a silent empty map.
+
+### Add / remove summary
+
+**Add:** filter chips row (A2) · scoped + tag-aware search (A3/A4) ·
+share button (E2) · search typeahead (F1) · immersive toggle (E1) ·
+footer sitemap links (C3) · ultrawide grid tier (D1).
+
+**Remove / simplify:** two-click tag flyout pattern (B1) · 300 ms
+re-click chip rule (B1) · tag-visibility 404s (B3) · breadcrumb
+level-skipping on public pages (B4) · **TagCloud** in its current form —
+replaced by an "Explore" block on HomePage (top tags as plain pills +
+"All tags →" link); weighted font-size clouds read as noise and
+duplicate the header bar's job.
+
+## Mockups
+
+### Desktop 16:9 — home with active filters
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ ◉ Site Title      Travel ▾  Photos ▾  Projects ▾        ⌕  ◐  🗺  ≡   │ header
+├────────────────────────────────────────────────────────────────────────┤
+│  Travel ×   2023 – 2024 ×                       Clear all · 23 posts   │ chips (A2)
+├────────────────────────────────────────────────────────────────────────┤
+│  ‹ ──────────────────  timeline (see timeline proposal) ───────────── ›│
+│                                                                        │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐                        │
+│  │  post      │  │  post      │  │  post      │   3 columns @1200px    │
+│  │  [pill][pill]  │  [pill]   │  │  [pill]    │   pills: 1 click = go  │
+│  └────────────┘  └────────────┘  └────────────┘   hover = family flyout│
+│                                                                        │
+│            ‹ prev      page 2 / 4 · 23 posts      next ›               │
+│  © Author                                   All tags · Map · About     │ footer (C3)
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Ultrawide 21:9 / 32:9 — home
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│        │ ◉ Site Title   Travel ▾ Photos ▾        ⌕ ◐ 🗺 ≡ │        │
+│  empty │  ┌────────────────────────┐ ┌──────────┐ ┌──────────┐      │  empty         │
+│  (32:9 │  │   featured (2 cols)    │ │  post    │ │  post    │      │  (capped at    │
+│  only) │  └────────────────────────┘ └──────────┘ └──────────┘      │  ~1800px,      │
+│        │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────┐│  centered)     │
+│        │  │  post    │ │  post    │ │  post    │ │  post    │ │post││                │
+│        │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └────┘│                │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+   21:9: container ~1800px → 4–5 columns, hero spans 2.   Map page: full-bleed instead.
+```
+
+### Phone portrait — home + long-press tag sheet
+
+```
+┌──────────────────────┐        ┌──────────────────────┐
+│ ◉ Title       ⌕  ≡  │        │ ░░ page dimmed ░░░░░ │
+│ Travel × 2023–24 × ✕ │  long- │ ┌──────────────────┐ │
+├──────────────────────┤  press │ │      ────        │ │
+│ ┌──────────────────┐ │  pill  │ │ World › Europe   │ │ ← ancestors
+│ │   post card      │ │ [Lisbon│ │ Lisbon       5 ● │ │ ← tap = go
+│ │   [Lisbon][2024] │ │  ───►  │ │ ──────────────── │ │
+│ └──────────────────┘ │        │ │ Alfama       2   │ │ ← children
+│ ┌──────────────────┐ │        │ │ Belém        1   │ │
+│ │   post card      │ │        │ └─ swipe down ─────┘ │
+│ └──────────────────┘ │        └──────────────────────┘
+│  ‹  page 2/4  ›      │          tap pill (short) = navigate
+└──────────────────────┘          long-press = this sheet
+```
+
+### Phone landscape — compact header
+
+```
+┌────────────────────────────────────────────────┐
+│ ◉   Travel ▾  Photos ▾              ⌕  ≡      │  ← single short row,
+│ ┌──────────────────┐ ┌──────────────────┐      │    no title text
+│ │    post card     │ │    post card     │      │  2 columns
+│ └──────────────────┘ └──────────────────┘      │
+└────────────────────────────────────────────────┘
+```
+
+### Post page ≥ 21:9 — reading column + side rail
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│            │  Post Title                      │ 12 Jun 2024    │
+│            │  Prose stays at 800px for        │ [Lisbon][2024] │
+│   empty    │  comfortable line length.        │ ⤢ immersive    │
+│            │  ┌────────────────────────────┐  │ ⇪ share        │
+│            │  │   figure breakout ~1200px  │  │ EXIF ▾         │
+│            │  └────────────────────────────┘  │  (sticky rail) │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Prioritized roadmap
+
+**P0 — stop harming (small, high-impact)**
+
+1. One click = navigate on all tag surfaces; remove two-click flyout and
+   300 ms chip re-click (B1)
+2. Fix tag-visibility 404s (B3)
+3. ≥ 44 px touch targets on pills and icon buttons via hit-slop (D3)
+4. Hover parity: visible carets, always-visible touch controls (D4)
+5. Map fetch error state (G)
+
+**P1 — make it legible**
+
+6. URL-backed view context module; Timeline / tag bar / search /
+   pagination all speak it (A1)
+7. Filter chips row + Clear all + aria-live (A2, G)
+8. Scoped search + tag-name matching with tag results strip (A3, A4)
+9. Ultrawide grid tier: `clamp()` container + hero-spans-2 (D1, D2)
+10. Phone-landscape compact header; `pointer: coarse` styles (D1)
+11. Share / copy-link on posts and immersive slides (E2)
+12. Footer sitemap links; burger canonical ordering (C1, C3)
+
+**P2 — make it delightful**
+
+13. Unified family flyout (hover-intent / long-press bottom sheet) (B2)
+14. Search typeahead + recent searches (F1)
+15. Immersive mode toggle + slide progress dots (E1, E3)
+16. Post-page side rail + figure breakout on ultrawide (D2)
+17. Replace TagCloud with Explore block (add/remove summary)
+18. `/tags` directory: collapse + filter box (B5)
+19. Lightbox/carousel component convergence (E4)
+
+## Considered and rejected
+
+- **Infinite scroll**: breaks URL-addressability, footer reachability, and
+  "where was I" — pagination + swipe already feels fluid here.
+- **Multi-tag AND/OR filtering UI**: real gap (you can't refine "camping"
+  within "travel"), but it needs API support (`/api/tags/slug/:slug/posts`
+  is single-tag) and a query-builder UI that fights the distraction-free
+  goal. The context model (A1) is designed so `tag` can become `tags[]`
+  later without rework. Deferred, not rejected forever.
+- **Mega-menu for the header tag bar**: heavier than the chips + flyout
+  model and collapses badly on mobile.
+- **Masonry grid**: visual interest at the cost of scan order and layout
+  shift; uniform cards + featured slot read better.
+- **Server-side rendering for SEO**: out of UX scope; orthogonal
+  infrastructure decision.
+- **Sticky sidebar on ultrawide** (timeline/tag tree pinned in the dead
+  space): tested badly against principle 4 — it's chrome filling space
+  for its own sake; more columns is the honest use of width.

--- a/docs/features/tag-system-proposal.md
+++ b/docs/features/tag-system-proposal.md
@@ -1,0 +1,470 @@
+# Tag System — Ground-Up Redesign Proposal
+
+Proposal for redesigning the tag system: hierarchy semantics, system-tag
+inheritance, and management in `/light/tags`. Proposal only — no
+implementation. Tracked under beads issue **point-krcu**, companion to the
+[Admin UX proposal](admin-ux-proposal.md), the
+[Public UX proposal](public-ux-proposal.md), and the
+[Timeline proposal](timeline-ux-proposal.md).
+
+## Background
+
+### What exists
+
+The taxonomy core is sound and predates everything else
+([META-TAGGING.md](META-TAGGING.md)): tags form a multi-parent DAG via
+`tag_relationships (parent_id, child_id)`, archives are recursive (a parent
+tag's page shows descendant posts), and post counts roll up through the
+hierarchy. None of that is in question here.
+
+On top of it sits the **system-tag mechanism**. Tags once had boolean
+columns (`is_featured`, `is_hidden`, `is_hidden_posts`,
+`include_in_breadcrumbs`, `show_related_tags_as_children`); migrations
+`system_tags_phase_a/b` (`queries_migrations.go`) moved those flags *into
+the graph*: a reserved tag with a `_`-prefixed slug per behavior, and
+"tag X has behavior B" encoded as the edge `_B → X`. Today there are
+**twelve** reserved slugs:
+
+| System tag | Meaning | Who inherits it | Status |
+|---|---|---|---|
+| `_system` | groups the others in the tree | — | cosmetic only |
+| `_root` | children appear in public nav | direct children only | live |
+| `_hidden` | tag hidden from public surfaces | **all descendants** | live |
+| `_hide_posts` | posts carrying the tag hidden from guests | **all descendants** | live |
+| `_is_in_breadcrumbs` | tag shown in breadcrumb path | direct children only | live |
+| `_with_related` | related tags shown as children | direct children only | live |
+| `_no_ancestors` | tag excluded from ancestor flyout | direct children only | live |
+| `_pending` | "unfiled" queue for parentless tags | direct children only | live, duplicated (see below) |
+| `_page` | descendants excluded from public grids | all descendants | half-dead: `PageTagIDs()` has no callers; only effect is via `PublicHiddenTagIDs` (≈ hidden) |
+| `_in_timeline` | descendants whose slug parses as an integer are timeline year tags | descendants that `CAST` to a year | live (timeline, map year filter) |
+| `_type_page` | post tagged with it renders as "page" | attached to posts, not tags | unreachable: `CreateTag` rejects `_` slugs and `Slugify` strips `_`, so it can only exist by hand-editing the DB |
+| `_type_audio` | post renders as "audio" | attached to posts | unreachable, same reason |
+
+### Why it feels overengineered
+
+1. **The graph means three unrelated things.** Taxonomy
+   (`travel → portugal`), behavior flags (`_hidden → friends`), and scoping
+   (`_in_timeline → 2024`). Every consumer must first decide which kind of
+   edge it is looking at, which is why the admin tree hard-codes a
+   `HIDDEN_SYSTEM` set, the parent picker hard-codes an `EXCLUDE` set, the
+   editor modal re-renders five specific parents as "Features" checkboxes
+   (that submit as `parent_ids`!), and the tree shows only `_root` and
+   `_pending` as top-level nodes.
+
+2. **Three different inheritance semantics**, distinguishable only by
+   reading the service code: direct-children-only (`_root`,
+   `_with_related`, `_is_in_breadcrumbs`, `_no_ancestors`, `_pending`),
+   full-descendant BFS (`_hidden`, `_hide_posts`, `_page`), and
+   descendants-whose-slug-casts-to-integer (`_in_timeline`). The docs have
+   already lost track: `hidden-visibility.md` states `is_hidden_posts`
+   does **not** propagate to children, while
+   `buildEffectivelyHiddenPostsTagIDs` propagates it to all descendants.
+   `features.md` still documents the dropped boolean columns.
+
+3. **Identity by string prefix.** "Is this a system tag?" is answered by
+   `strings.HasPrefix(slug, "_")` at 19 call sites plus
+   `NOT LIKE '\_%' ESCAPE '\'` in 10 SQL queries. The prefix is load-bearing
+   in validation, filtering, breadcrumbs, tag clouds, and migrations — and
+   it has already collided with itself once (`DropTagNameUnique` exists
+   solely because a user tag wanted the display name "root").
+
+4. **Every public read recomputes the world.** Because flags live in the
+   graph, answering "is this tag hidden?" requires loading *all* tags and
+   *all* relationships and running a BFS. `tag_service.go` (1,151 lines) is
+   mostly seven near-identical set-builders (`EffectivelyHiddenIDs`,
+   `PublicHiddenTagIDs`, `EffectivelyHiddenPostsTagIDs`, `WithRelatedIDs`,
+   `InBreadcrumbsIDs`, `PageTagIDs`, `buildEffectivelyHidden*`). One
+   `GET /api/tags/slug/:slug` as a guest loads the full tag graph **four
+   times** and runs the full recursive post-count CTE **three times**.
+   Handlers call these in 44 places.
+
+5. **Writes are fragile.** The API is PUT-everything: the modal must echo
+   back name, slug, parents, children, and locations on every save. Two
+   live consequences: every save wipes `custom_url` (UI always sends `''`)
+   and — worse — **every save resets `sort_order` to NULL** (UI always
+   sends `null`), silently destroying the drag-and-drop ordering the user
+   set in the tree. Additionally `sort_order` is a single column on the
+   tag, but a multi-parent tag sits in several sibling groups: reordering
+   it under one parent clobbers its position under every other parent. A
+   drag-*onto* in the tree sets `parent_ids: [target]`, silently discarding
+   all other parents.
+
+6. **Duplicate and dead mechanisms.** "Unfiled" exists twice: as real
+   `_pending` edges (auto-assigned in `SetTagParents` and
+   `getOrCreateTag`) *and* as a virtual presentation-layer injection in the
+   `ListTags` handler for parentless tags. Cycle handling exists only
+   defensively (visited-sets and `UNION` recursion guards everywhere)
+   because nothing prevents writing a cycle. `custom_url` is write-only.
+   `_system` is decoration. `PageTagIDs` is dead code.
+
+The system-tag experiment bought one real thing — adding a behavior without
+a schema migration — and paid for it with three inheritance semantics, a
+string-prefix type system, per-request graph rebuilding, and an admin UI
+whose main job is hiding the model from the user. For a single-author blog
+that owns its schema and already has a disciplined `migration_history`
+mechanism, that trade is upside-down.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| What the hierarchy means | **Taxonomy only.** Behaviors move to typed columns on `tags`; system tags are removed entirely | One meaning per edge; the admin tree can show the whole truth; consumers stop classifying edges |
+| Multi-parent DAG | **Keep**, with cycle rejection at write time | Multi-parent is genuinely used (`lisbon` under both `portugal` and `cities`); defensive-only cycle handling is replaced by prevention |
+| Inheritance | **One rule**: visibility flags (`hidden`, `hides_posts`) inherit to all descendants; everything else applies to the tag itself only | Replaces three semantics with one sentence; matches the only inheritance users actually rely on (hide a subtree) |
+| Year tags | Explicit `kind = 'year'` column instead of the `_in_timeline` subtree | "Is a year" is a property of the tag, not its ancestry; timeline queries become an indexed filter instead of a recursive CTE |
+| Post types | `_type_page` / `_type_audio` retire; post type becomes a `posts` concern | They are unreachable through the UI today; a post's render type was never a taxonomy fact |
+| Unfiled | **Computed**: a tag with no parents is unfiled; `_pending` (both copies) removed | One source of truth; aligns with the admin proposal's pinned Unfiled queue (F3) |
+| Sibling ordering | `sort_order` moves to the **edge** (`tag_relationships`); nav membership/order becomes `nav_order` on the tag | A tag has one position *per parent*; fixes the cross-group clobbering and the save-wipes-order bug class |
+| Derived state | One in-process **tag-graph snapshot**, rebuilt on tag/post-tag writes | Single-process SQLite makes this trivially safe; replaces 4× graph loads + 3× count CTEs per request with one lookup |
+| Write API | **PATCH semantics** + a dedicated `move` operation | Saves change only what was edited; the wipe bugs become unrepresentable |
+
+## Design principles
+
+1. **An edge means "is part of", always.** If a fact is not taxonomy, it
+   does not live in the graph.
+2. **Properties are visible where they live.** A flag is a typed column on
+   the row you're looking at — not an edge to a magic node three hops away.
+3. **One inheritance rule, stated in one sentence.** Visibility flows down;
+   nothing else does.
+4. **Invalid states are unrepresentable.** Cycles rejected on write; flags
+   can't be "half-set" through a stale `parent_ids` echo; partial updates
+   can't destroy unrelated fields.
+5. **Read paths compute nothing twice.** Derived sets (effective hidden,
+   rolled-up counts, nav tree) come from one snapshot with one rebuild
+   point.
+
+## Proposed design
+
+### A. Data model
+
+```sql
+tags
+  id            INTEGER PRIMARY KEY
+  name          VARCHAR(100) NOT NULL
+  slug          VARCHAR(100) NOT NULL UNIQUE
+  description   TEXT
+  kind          TEXT NOT NULL DEFAULT 'topic'   -- 'topic' | 'year'
+  hidden        BOOLEAN NOT NULL DEFAULT 0      -- inherits ↓
+  hides_posts   BOOLEAN NOT NULL DEFAULT 0      -- inherits ↓
+  nav_order     INTEGER                          -- NULL = not in public nav
+  in_breadcrumbs BOOLEAN NOT NULL DEFAULT 0
+  show_related  BOOLEAN NOT NULL DEFAULT 0
+  in_ancestor_flyout BOOLEAN NOT NULL DEFAULT 1  -- inverts _no_ancestors
+  latitude      REAL                             -- tag_locations folds in
+  longitude     REAL                             --   (already 1:1 by UNIQUE)
+  post_count    INTEGER NOT NULL DEFAULT 0       -- denormalized, as today
+  created_at    DATETIME NOT NULL
+
+tag_relationships
+  parent_id     INTEGER NOT NULL REFERENCES tags ON DELETE CASCADE
+  child_id      INTEGER NOT NULL REFERENCES tags ON DELETE CASCADE
+  sort_order    INTEGER NOT NULL DEFAULT 0       -- position under THIS parent
+  PRIMARY KEY (parent_id, child_id)
+```
+
+Dropped: `custom_url` (write-only today), `tags.sort_order` (replaced by
+per-edge order + `nav_order`), the `tag_locations` table (folds into two
+nullable columns), and **all twelve system tags**.
+
+Write-time invariants (service layer, not constraints):
+
+- `AddTagRelationship(p, c)` walks `c`'s descendants; if `p` is among
+  them → `409 Conflict`. All the visited-set scaffolding in read paths
+  becomes belt-and-suspenders instead of the only line of defense.
+- `kind = 'year'` requires the slug to parse as a year (`2024`, `2020s`) —
+  the same `CAST` rule the timeline uses today, enforced at the door
+  instead of assumed downstream.
+- The `_` slug prefix becomes free after migration (nothing reserved
+  remains); `DropTagNameUnique`-style workarounds end.
+
+### B. One inheritance rule
+
+> A tag is **effectively hidden** (or effectively hides its posts) if the
+> flag is set on the tag itself or on any ancestor. No other property
+> inherits.
+
+- `hidden` — tag disappears from nav, cloud, tag pages, breadcrumbs,
+  flyouts for guests; direct URL → 404. (Same as today's `_hidden`.)
+- `hides_posts` — posts carrying the tag (or any descendant tag) are
+  guest-invisible. (Same as today's `_hide_posts`, and now the docs and
+  the code will agree that it propagates.)
+- `nav_order`, `in_breadcrumbs`, `show_related`, `in_ancestor_flyout`,
+  `kind`, coordinates — apply to the tag itself only, exactly as their
+  system-tag predecessors did (direct-children semantics becomes "set on
+  this tag").
+- `min_tag_posts_to_show` keeps its current meaning, applied to effective
+  (rolled-up) counts at read time.
+
+The admin UI distinguishes *set here* from *inherited*: an inherited flag
+renders as a non-interactive "Hidden — via Travel" chip linking to the
+ancestor that set it (see E).
+
+### C. The tag-graph snapshot
+
+A single in-memory structure owned by `TagService`:
+
+```
+TagGraph {
+  byID, bySlug          map lookups
+  children, parents     adjacency (edges ordered by edge sort_order)
+  effectiveHidden       set  (BFS from hidden=1 tags, computed once)
+  effectiveHidesPosts   set
+  countsPublic, countsAdmin  map[tagID]int64   (one recursive CTE each)
+  navTree               []NavTagNode           (from nav_order tags)
+  yearTags              []Tag                  (kind='year', sorted)
+}
+```
+
+- Built lazily on first read; **invalidated** by any tag write and any
+  post-tag mutation (post save / publish / schedule-fire / delete /
+  restore). Single process + SQLite = no coherence problem.
+- Every current set-builder (`EffectivelyHiddenIDs`,
+  `PublicHiddenTagIDs`, `EffectivelyHiddenPostsTagIDs`, `WithRelatedIDs`,
+  `InBreadcrumbsIDs`, `PageTagIDs`) and `GetHierarchicalNavTags` becomes a
+  field read. The seven BFS implementations collapse into one builder
+  function; `tag_service.go` shrinks from ~1,150 lines to a builder plus
+  thin accessors. Handlers stop orchestrating 4–6 service calls per
+  request.
+- Timeline and map year-range queries (`queries_timeline.go`,
+  `queries_posts.go`) drop their `_in_timeline` recursive CTE preambles
+  for `WHERE kind = 'year' AND CAST(slug AS INTEGER) BETWEEN ? AND ?`.
+
+### D. API
+
+**Reads.** Tag objects gain explicit, truthful fields:
+
+```json
+{
+  "id": 7, "name": "Friends", "slug": "friends", "kind": "topic",
+  "hidden": false,        "effective_hidden": true,
+  "hides_posts": true,    "effective_hides_posts": true,
+  "hidden_via": 3,
+  "nav_order": null, "in_breadcrumbs": false, "show_related": false,
+  "in_ancestor_flyout": true,
+  "parents": [...], "children": [...],
+  "latitude": null, "longitude": null,
+  "post_count": 12
+}
+```
+
+`is_system` disappears (nothing is a system tag), the virtual `_pending`
+parent injection disappears, and guests simply never receive
+effectively-hidden tags — the existing guest/admin filtering contract
+(`hidden-visibility.md`) is unchanged in spirit and finally matches the
+implementation.
+
+**Writes.**
+
+- `PATCH /api/tags/:id` — partial update of scalar fields only
+  (name, slug, description, kind, the five flags, coordinates). Absent
+  field = untouched. The sort-order and custom-url wipe bugs become
+  impossible by construction.
+- `PUT /api/tags/:id/parents` and `/children` — structure edits stay
+  explicit set-replacement (the modal's mental model), but only structure:
+  flags no longer ride along in `parent_ids`.
+- `POST /api/tags/:id/move {parent_id, after_id}` — one operation for the
+  tree's drag-and-drop: creates/keeps the edge to `parent_id`, positions
+  the edge after `after_id` (NULL = first), renumbers only that sibling
+  group. Replaces today's split brain (`reorderTag` + reparent-via-update)
+  and never touches the tag's other parents.
+- `POST /api/tags` — as today, plus optional flags; parentless creation is
+  legal and lands in Unfiled (no `_pending` edge writes).
+- Cycle attempts → `409` with the offending path in the message.
+
+### E. Admin `/light/tags`
+
+The page stops hiding the model because there is nothing left to hide:
+
+- **Tree = the whole truth.** Top level shows nav tags (ordered by
+  `nav_order`), then other filed roots, then a pinned **Unfiled (N)**
+  group (computed; admin proposal F3). No `HIDDEN_SYSTEM` set, no
+  lock-icon system rows, no virtual parents.
+- **Row badges** replace buried state: `⌂ nav` (in navigation), `🚫 hidden`
+  / `🚫̃ inherited` (dimmed, links to the ancestor that set it), `📍`
+  (coordinates), `📅` (year tag). A multi-parent row keeps the `⎇ also
+  under…` hint.
+- **Editor modal** groups by what things now are:
+  - *Identity*: name, slug, description — unchanged.
+  - *Visibility*: Hidden, Hide posts — toggles with inherited state shown
+    as read-only chips ("inherited from Travel — change there").
+  - *Display*: In navigation (with position), In breadcrumbs, Show related
+    tags, Show in ancestor flyout.
+  - *Kind*: Topic / Year (year validates slug).
+  - *Structure*: parent/children pickers as today, minus the `EXCLUDE`
+    list and the flags-as-checkboxes hack; the picker shows the real tree.
+  - *Coordinates*: unchanged (parse / geocode).
+  - Saves issue one `PATCH` (+ structure calls only if structure changed).
+- **Ordering**: dragging within a parent reorders that edge group only;
+  drag-onto opens a confirm ("Move under X / Also file under X") instead
+  of silently discarding other parents; every drag has a `Move…` dialog
+  twin (admin proposal F4 — touch parity).
+- **Breadcrumb determinism**: `GetTagAncestors` today walks "first
+  eligible parent" in undefined order; with per-edge `sort_order` the
+  primary parent is defined (lowest-ordered edge), so breadcrumbs for
+  multi-parent tags stop being arbitrary.
+
+### F. Migration
+
+One idempotent migration in the existing `migration_history` pattern
+(`tag_flags_from_system_tags`), the exact inverse of `system_tags_phase_a`:
+
+1. Add new columns to `tags`; add `sort_order` to `tag_relationships`
+   (seeded from the child's current `tags.sort_order`).
+2. Translate edges to columns:
+   `_hidden → hidden=1` · `_hide_posts → hides_posts=1` ·
+   `_root → nav_order = old sort_order` · `_is_in_breadcrumbs →
+   in_breadcrumbs=1` · `_with_related → show_related=1` ·
+   `_no_ancestors → in_ancestor_flyout=0` · `_in_timeline` descendants →
+   `kind='year'` · `_page` descendants → `hidden=1` · `_pending`,
+   `_system` → nothing (computed/cosmetic).
+3. Fold `tag_locations` into the new columns; migrate posts tagged
+   `_type_page`/`_type_audio` (if any exist in the wild) to the post-side
+   type representation; then delete all `_`-prefixed tags — cascade
+   removes their edges and `post_tags` rows.
+4. Drop `tags.sort_order`, `custom_url`, `tag_locations`; recompute counts.
+5. Docs pass: rewrite `hidden-visibility.md` (it currently documents
+   dropped columns *and* contradicts the code on `_hide_posts`
+   inheritance), update the Tagging table in `features.md`, append the new
+   model to `META-TAGGING.md`.
+
+Rollback safety: the migration is a pure transformation of existing data;
+a pre-migration backup via the existing System backup is the escape hatch,
+same as phase a/b had.
+
+### G. What stays untouched
+
+The multi-parent DAG and its recursive archives and counts; slug-based
+public URLs; `min_tag_posts_to_show`; co-occurring related tags;
+geocoding (Nominatim) and the map; the public-side tag UX defined in the
+public proposal (flyout/sheet, one-click navigation); the admin-side tag
+workflow defined in the admin proposal (hierarchy-aware autocomplete,
+Unfiled queue, Move/Merge) — this proposal is the data-model floor those
+two stand on.
+
+## Add / remove summary
+
+**Add:** typed flag columns + `kind` on `tags` (A) · per-edge `sort_order`
+(A) · write-time cycle rejection (A) · one inheritance rule with
+`effective_*` + `hidden_via` in responses (B/D) · tag-graph snapshot with
+single invalidation point (C) · `PATCH` tags + `move` operation (D) ·
+inherited-state chips and truth-telling tree in `/light/tags` (E).
+
+**Remove:** all twelve system tags and the `_` prefix reservation ·
+flags-as-parentage and the three inheritance semantics · 29
+slug-prefix checks (19 Go + 10 SQL) · seven BFS set-builders and the
+4×-graph-loads-per-request pattern · `_pending` (both the real edges and
+the virtual injection) · `custom_url` and `tags.sort_order` ·
+`tag_locations` as a table · the modal's `EXCLUDE`/`HIDDEN_SYSTEM`/
+Features-checkbox machinery · the save-wipes-sort-order and
+save-wipes-custom-url bugs · `PageTagIDs` dead code ·
+`DropTagNameUnique`-class collisions.
+
+## Mockups
+
+### `/light/tags` — tree as the whole truth
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Tags                                  [Tree|List]  + New │
+├──────────────────────────────────────────────────────────┤
+│ ⚠ UNFILED (2)                                            │
+│   alfama          · 3   [File under…] [Edit]             │
+│   sintra-night    · 1   [File under…] [Edit]             │
+├──────────────────────────────────────────────────────────┤
+│ ▾ Travel  ⌂1 · 48                       [✎][+][Move…][×] │
+│   ▾ Portugal 📍 · 12                    [✎][+][Move…][×] │
+│       Lisbon 📍 · 9  ⎇ also under Cities                 │
+│ ▾ Life  ⌂2 · 31                                          │
+│     Friends  🚫 hide-posts · 12                          │
+│       BBQs   🚫̃ inherited · 3      ← chip links to Friends│
+│ ▾ Years 📅 (kind=year, flat) 2017 … 2026                 │
+└──────────────────────────────────────────────────────────┘
+  ⌂n = nav position · 🚫 = set here · 🚫̃ = inherited · no lock rows
+```
+
+### Editor modal — flags are fields, not parents
+
+```
+┌─ Edit: Friends ──────────────────────────── 12 posts ──┐
+│ Name  [Friends            ]   /tags/[friends         ] │
+│ Description [……………………………………………………]                     │
+│                                                        │
+│ VISIBILITY                                             │
+│  ( ) Visible  (•) Hidden from public                   │
+│  [✓] Hide posts carrying this tag                      │
+│      ↳ applies to BBQs, Dinners (2 descendants)        │
+│                                                        │
+│ DISPLAY                                                │
+│  [ ] In navigation   position [—]                      │
+│  [ ] In breadcrumbs  [ ] Show related  [✓] In flyout   │
+│                                                        │
+│ KIND   (•) Topic  ( ) Year                             │
+│ ▸ Parents (1: Life)    ▸ Children (2)    ▸ Coordinates │
+│                                                        │
+│                          [Cancel]  [Save changes]      │
+└────────────────────────────────────────────────────────┘
+  Save = PATCH of changed fields only
+```
+
+## Prioritized roadmap (task breakdown)
+
+**P0 — model and floor (everything else stands on this)**
+
+1. Schema migration `tag_flags_from_system_tags` (A, F1–F4) with
+   backup-first note in release notes
+2. Cycle rejection in `AddTagRelationship` (+ tests for the 409 path)
+3. Tag-graph snapshot + invalidation hooks on tag/post-tag writes (C);
+   port all read paths (handlers, nav, breadcrumbs, cloud, timeline, map)
+4. Delete the seven set-builders, prefix checks, and `_in_timeline` CTE
+   preambles as the ports land (the deletion *is* the deliverable)
+
+**P1 — API and admin UI**
+
+5. `PATCH /api/tags/:id`; structure endpoints; `move` operation (D)
+6. TagsManagerPage: badges, Unfiled group, Visibility/Display/Kind modal
+   groups, inherited chips (E)
+7. Drag-and-drop on per-edge order + drag-onto confirm + `Move…` dialog
+   (E; overlaps admin proposal F4)
+8. Docs rewrite: `hidden-visibility.md`, `features.md` tagging table,
+   `META-TAGGING.md` addendum (F5)
+
+**P2 — follow-through**
+
+9. Post type off tags: `posts`-side representation replacing
+   `_type_page`/`_type_audio` in `getPostType` (D, F3)
+10. Free the `_` slug prefix; remove `DropTagNameUnique` (A)
+11. Admin-proposal tag items that now become straightforward: Unfiled
+    file-under/merge actions (F3/F5 there), hierarchy-aware autocomplete
+    paths from the snapshot (F1 there)
+
+## Considered and rejected
+
+- **Keep system tags, just unify inheritance semantics.** Fixes one of the
+  seven symptoms; the string-prefix type system, per-request BFS, UI
+  hiding machinery, and flags-in-`parent_ids` all remain. The mechanism is
+  the cost, not its inconsistency.
+- **A `tag_attributes (tag_id, key)` table instead of columns.** Re-creates
+  system tags one table over: string-keyed, untyped, invisible on the row,
+  and still requiring a join/set-build to answer "is this tag hidden?".
+  Five booleans and an enum on a single-author blog do not need an EAV
+  escape hatch; the project demonstrably knows how to migrate schema.
+- **Strict tree instead of DAG.** Multi-parent is genuinely used and cheap
+  once edges only mean taxonomy; the painful parts (ordering, breadcrumbs,
+  drag-onto) are fixed by per-edge order and a defined primary parent, not
+  by banning the second parent.
+- **Closure table / materialized ancestry in SQLite.** Write amplification
+  and a second source of truth to keep consistent, to optimize reads that
+  an in-process snapshot already makes O(1). Wrong tool at this scale
+  (hundreds of tags, one process).
+- **Per-post visibility instead of `hides_posts` on tags.** The real use
+  case is "hide everything about this person/place" — a subtree property.
+  Post-level hiding already exists (`status: hidden`) and stays.
+- **Renaming/aliasing system tags into a nicer UI without model change.**
+  The admin proposal's F-section already does this as far as it can go;
+  this proposal exists because the remaining problems (inheritance
+  semantics, wipe bugs, per-request rebuilds) live below the UI.
+- **Doing nothing.** Two of the findings are live correctness bugs (every
+  modal save destroys manual ordering; docs contradict code on
+  `_hide_posts` inheritance), and every new tag feature inherits the
+  three-semantics tax. The floor needs fixing before the UX proposals
+  build on it.

--- a/docs/features/timeline-ux-proposal.md
+++ b/docs/features/timeline-ux-proposal.md
@@ -1,0 +1,222 @@
+# Timeline Control — Best-in-Class UX Proposal
+
+UX proposal for the Timeline control on desktop and mobile. Proposal only — no
+implementation yet. Tracked under beads issue **point-krcu**.
+
+## Background
+
+The Timeline (`frontend/src/components/public/Timeline.js`,
+`frontend/css/public/timeline.css`) is a horizontal pan/zoom control showing
+year tags as pills, used in two modes: **popover** (public pages — click a
+year, see its locations) and **filter** (HomePage/MapPage — the centered
+year/range filters posts/pins live).
+
+The engineering underneath is already strong: collision clustering,
+snap-to-center, 320 ms eased animations, throttled live filtering, pinch/swipe
+gestures, decade ticks. What keeps it from best-in-class is **UX, not
+mechanics**:
+
+1. **It hijacks the page.** `touch-action: none` means a vertical swipe
+   starting on the timeline zooms it instead of scrolling the page (mobile's
+   #1 sin). On desktop, plain mouse-wheel is captured for zoom, trapping page
+   scroll whenever the cursor crosses the control.
+2. **It's mute at rest.** The collapsed state is a single mysterious cluster
+   pill. Nothing signals "drag me," vertical-drag-zoom is undiscoverable, and
+   `post_count` data — already in the API payload — is never visualized.
+3. **Selection is implicit.** In filter mode the "current range" is only a
+   20 %-opacity center line plus a highlighted pill; there is no readable
+   range readout and no obvious way to reset to "all years."
+4. **Mobile is desktop-shrunk.** Pills are ~28 px tall (below the 44 px touch
+   minimum), and the locations popover is a tiny anchored card instead of a
+   thumb-friendly sheet.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scope | Evolve the existing pan/zoom pill-track model | The mechanics are solid; the gaps are affordances, legibility, and platform fit |
+| Mobile vertical swipe | Scrolls the **page** (`touch-action: pan-y`); vertical-drag-zoom removed on touch | Never block page scrolling; pinch + double-tap cover zoom |
+| Desktop wheel | **Ctrl/Cmd + wheel** zooms; plain wheel passes through to the page | Maps/Figma convention; eliminates the scroll trap |
+
+## Design principles
+
+1. **Informative at rest, navigable on intent.** The control should
+   communicate "this is your life over time" before anyone touches it.
+2. **Never steal the page.** Scrolling past the timeline must always work;
+   timeline gestures must be deliberate.
+3. **Every gesture has a visible alternative.** Drag has chevrons; pinch has
+   double-tap; zoom has a hint.
+4. **One mental model, device-native gestures.** Same pan/zoom/snap semantics
+   everywhere; the gestures differ per input device.
+
+## Proposed design
+
+### A. Visual layer (both platforms)
+
+**A1. Density histogram.** Render subtle vertical bars (or a soft area fill)
+along the axis, height ∝ `post_count` per year — the data is already in the
+`/api/timeline` payload. This is the Google Photos / Flickr scrubber pattern:
+the timeline becomes a picture of the archive, clusters stop feeling
+arbitrary, and empty years read as intentional gaps. Color: `--border-subtle`
+at rest, `--color-primary` at low opacity within the active range.
+
+**A2. Range readout chip (filter mode).** A small persistent chip at the
+top-center of the track: `2014 – 2024 · 87 posts`. It updates live during drag
+(the throttled emit already exists) and doubles as the **reset control** —
+when the range ≠ full extent it gains an `×`; clicking it animates back to the
+collapsed "all years" state. This makes the current filter readable, the
+filter's existence obvious, and undo one click.
+
+**A3. Honest collapsed state.** Instead of a lone cluster pill, the collapsed
+state shows an **"All years · N posts"** pill plus the density histogram
+across the full extent. First interaction per browser (localStorage flag)
+shows a one-time ghost hint under the track: *"Drag to explore · pinch or
+Ctrl+scroll to zoom."*
+
+**A4. Edge affordances.** Keep the gradient fade masks; **re-enable the
+chevron nav buttons** that are already implemented but commented out
+(`Timeline.js` render(), `_updateNavButtons` logic exists). Desktop: fade in
+on container hover when content overflows. Mobile: always visible when
+overflowing (smaller, 28 px).
+
+**A5. Stronger center indicator (filter mode only).** Replace the
+20 %-opacity full-height line with a short caret/notch at the axis plus the
+readout chip. In popover mode (no center semantics), hide the indicator
+entirely — today it implies a selection that doesn't exist.
+
+**A6. Cluster fan-out.** When a cluster expands (zoom-to-fit), pills animate
+outward from the cluster's position rather than re-rendering in place — the
+existing `_animateTo` easing covers the pan/zoom, but pills should transition
+`left` (`transition: left 200ms` during programmatic zoom only, never during
+drag).
+
+### B. Desktop interactions
+
+| Input | Action |
+|---|---|
+| Drag track | Pan (kept), add momentum flick |
+| **Ctrl/Cmd + wheel** | Zoom around cursor |
+| Plain wheel | **Passes through to page scroll**; transient hint "Use ⌘/Ctrl + scroll to zoom" appears (Google Maps pattern, ~1.5 s fade) |
+| Shift + wheel / trackpad horizontal | Pan |
+| Vertical mouse drag | Zoom (kept — now a bonus path, not the only one) |
+| Double-click track | Zoom in ~2× around point; Alt + double-click zooms out |
+| Hover axis | Year tooltip under cursor (`2019`) |
+| Hover pill | Tooltip `2019 · 12 posts` (counts are currently invisible until popover opens) |
+| Click readout chip `×` | Reset to all years |
+
+**Keyboard (track is one tab stop):** `←`/`→` move focus between
+pills/clusters and auto-scroll (exists); `+`/`-` zoom around center;
+`Home`/`End` jump to extents; `Enter`/`Space` activate focused pill; `Esc`
+closes popover (exists), second `Esc` resets zoom. An `aria-live="polite"`
+region announces range changes ("Showing 2014 to 2024, 87 posts") and pill
+focus ("2019, 12 posts").
+
+### C. Mobile interactions
+
+| Input | Action |
+|---|---|
+| Vertical swipe | **Scrolls the page** (`touch-action: pan-y`; remove the `stopPropagation` + vertical-zoom path for touch) |
+| Horizontal swipe | Pan with momentum, then snap-to-center (snap exists) |
+| Pinch | Zoom (kept) |
+| Double-tap | Zoom in around tap point |
+| Two-finger tap | Zoom out (Maps convention) |
+| Tap pill | Same as click |
+
+- **Touch targets:** pills get invisible hit-slop to ≥ 44 px (pseudo-element
+  or padding on the wrapper, visual size unchanged); track height 56 → 64 px
+  on coarse pointers (`@media (pointer: coarse)`).
+- **Locations popover → bottom sheet** on viewports < 640 px: slides up from
+  the bottom, larger rows, swipe-down or scrim-tap to dismiss. Anchored
+  popovers near the top edge on a phone are cramped and finger-occluded; this
+  is the standard mobile resolution. The clicked year remains the first row
+  (existing rule — keep).
+- **Haptic tick** on snap-to-center where supported (`navigator.vibrate(10)`),
+  respecting reduced-motion.
+
+### D. Mode-specific notes
+
+- **Filter mode (Home/Map):** live readout chip (A2) + reset; URL sync
+  (`?timeline=`, `/map/2024-2026`) already works — unchanged.
+- **Popover mode:** add `role="dialog"`, focus moves into popover on open and
+  returns to the pill on close, arrow keys traverse the location list. Keep
+  the "clicked year is always the first navigable item" rule.
+- **Reduced motion:** extend the existing `prefers-reduced-motion` block to
+  skip momentum, fan-out, sheet slide, and haptics.
+
+## Mockups
+
+### Desktop — filter mode, mid-zoom
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                         ┌──────────────────────┐                         │
+│  ‹                      │ 2014 – 2024 · 87  ✕  │                      ›  │
+│                         └──────────────────────┘                         │
+│   ▂▃▂  ▅▂▃▁▂▃▆▂▃▅▇▅▃▂▁▂▃▅▂▁▃▂▅▃▂▃▁  ← density histogram                  │
+│  (2009–2012) (2013) (2014)  ▾  [2019]  (2020) (2021–2022) (2024)         │
+│ ──┴───────────┴────────┴────────┴────────┴──────────┴─────────┴──        │
+│  2010                 center caret ▴ + active pill   2020                │
+└──────────────────────────────────────────────────────────────────────────┘
+   hover: ░ 2017 · 9 posts ░        plain scroll → "Use ⌘+scroll to zoom"
+```
+
+### Desktop — collapsed (at rest)
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│        ▁▂▃▂▅▂▃▁▂▃▆▂▃▅▇▅▃▂▁▂▃▅▂▁▃▂▅▃▂▃▁▂▃▂▁▂▃▂▅▃▂                         │
+│                      ( All years · 312 posts )                           │
+│ ──┬──────────┬──────────┬──────────┬──                                   │
+│  1990       2000       2010       2020                                   │
+│         "Drag to explore · pinch or Ctrl+scroll to zoom"  (first visit)  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Mobile — popover mode with bottom sheet
+
+```
+┌────────────────────────────┐      ┌────────────────────────────┐
+│  ▂▃▅▇▅▃▂▁▂▃▅▂▁▃▂▅▃         │      │ ░░░░░ page dimmed ░░░░░░░  │
+│ ‹ (2013–2015) [2019] (2021)│  tap │ ┌────────────────────────┐ │
+│ ──┴──────┴──────┴────── ›  │ 2019 │ │        ────            │ │
+│   vertical swipe = page    │ ───► │ │  2019          12 ●    │ │
+│   scroll; pinch = zoom     │      │ │  ──────────────────    │ │
+└────────────────────────────┘      │ │  Lisbon          5     │ │
+                                    │ │  Kyiv            4     │ │
+                                    │ │  Batumi          3     │ │
+                                    │ └── swipe down to close ─┘ │
+                                    └────────────────────────────┘
+```
+
+## Prioritized roadmap
+
+**P0 — stop harming (small, high-impact fixes)**
+
+1. `touch-action: pan-y`; remove touch vertical-zoom + `stopPropagation` on
+   touchstart/touchmove
+2. Ctrl/Cmd+wheel zoom; plain wheel passes through + transient hint
+3. Re-enable chevron nav buttons (code exists, commented out)
+4. ≥ 44 px touch targets + 64 px track on coarse pointers
+
+**P1 — make it legible**
+
+5. Range readout chip + reset (filter mode)
+6. Density histogram from `post_count`
+7. Honest collapsed state + one-time gesture hint
+8. Hover tooltips (year under cursor, pill counts)
+9. Hide center indicator in popover mode; caret style in filter mode
+
+**P2 — make it delightful**
+
+10. Bottom sheet for mobile popovers
+11. Momentum panning, double-tap / double-click zoom, two-finger-tap zoom out
+12. Cluster fan-out transition
+13. Keyboard zoom (`+`/`-`, `Home`/`End`) + `aria-live` announcements +
+    popover focus management
+14. Haptic snap tick
+
+## Considered and rejected
+
+- **Brush/range handles** (finance-chart pattern): heavier UI for marginal
+  gain since center-snap + cluster tap already select ranges.
+- **Month-level zoom**: the data model is year tags only.


### PR DESCRIPTION
## Summary

Proposal-only document (no code changes): `docs/features/timeline-ux-proposal.md` — a best-in-class UX design for the Timeline control on desktop and mobile.

Key points:
- **Stop hijacking the page**: `touch-action: pan-y` on mobile (vertical swipe scrolls the page), Ctrl/Cmd+wheel zoom on desktop (plain wheel passes through)
- **Informative at rest**: density histogram from `post_count`, honest collapsed state, one-time gesture hint
- **Legible selection**: range readout chip (`2014 – 2024 · 87 posts`) doubling as reset, caret center indicator
- **Mobile-native**: ≥44 px touch targets, bottom sheet instead of anchored popover, double-tap zoom, haptic snap
- **Accessibility**: keyboard zoom, `aria-live` range announcements, popover focus management
- Prioritized P0–P2 roadmap + rejected alternatives

Tracked as beads issue **point-krcu**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)